### PR TITLE
Zero-downtime indexing + asynchronous indexing on startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,10 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/io/quarkus/search/app/health/IndexContentHealthCheck.java
+++ b/src/main/java/io/quarkus/search/app/health/IndexContentHealthCheck.java
@@ -1,0 +1,50 @@
+package io.quarkus.search.app.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
+/**
+ * Checks that the indexes were populated.
+ */
+@Readiness
+@ApplicationScoped
+public class IndexContentHealthCheck implements HealthCheck {
+    private static final String NAME = "Index content";
+
+    @Inject
+    SearchSession session;
+
+    @Override
+    @Transactional
+    public HealthCheckResponse call() {
+        try {
+            long totalHitCount = session.search(Object.class)
+                    .where(f -> f.matchAll())
+                    .fetchTotalHitCount();
+            if (totalHitCount > 0L) {
+                return HealthCheckResponse.builder()
+                        .name(NAME).up()
+                        .withData("details", "Indexes contain " + totalHitCount + " elements")
+                        .build();
+            } else {
+                return HealthCheckResponse.builder()
+                        .name(NAME).down()
+                        .withData("details", "Indexes are empty")
+                        .build();
+            }
+        } catch (RuntimeException e) {
+            return HealthCheckResponse.builder()
+                    .name(NAME).down()
+                    .withData("details", "Cannot reach indexes")
+                    .withData("exception", e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/io/quarkus/search/app/indexing/Rollover.java
+++ b/src/main/java/io/quarkus/search/app/indexing/Rollover.java
@@ -1,0 +1,180 @@
+package io.quarkus.search.app.indexing;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchBackend;
+import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
+import org.hibernate.search.backend.elasticsearch.index.ElasticsearchIndexManager;
+import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
+import org.hibernate.search.engine.common.schema.management.SchemaExport;
+import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.hibernate.search.mapper.pojo.schema.management.SearchSchemaCollector;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.quarkus.logging.Log;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+
+/**
+ * Implementation of a rollover,
+ * i.e. a three-step process that creates new indexes and redirects write aliases to those new indexes,
+ * then let the caller run indexing,
+ * then commits or rolls back by atomically pointing aliases to the new (respectively old) index
+ * and removing the old (respectively new) index.
+ */
+public class Rollover implements Closeable {
+
+    public static Rollover start(SearchMapping searchMapping) {
+        Log.info("Starting index rollover");
+
+        var mappings = new HashMap<String, JsonObject>();
+        var settings = new HashMap<String, JsonObject>();
+        var schemaCollector = new SearchSchemaCollector() {
+            @Override
+            public void indexSchema(Optional<String> backendName, String indexName, SchemaExport export) {
+                var createIndexRequestBody = export.extension(ElasticsearchExtension.get()).bodyParts().get(0);
+                mappings.put(indexName, createIndexRequestBody.getAsJsonObject("mappings"));
+                settings.put(indexName, createIndexRequestBody.getAsJsonObject("settings"));
+            }
+        };
+        searchMapping.scope(Object.class).schemaManager().exportExpectedSchema(schemaCollector);
+
+        var client = client(searchMapping);
+        var gson = new Gson();
+        List<IndexRolloverResult> successfulRollovers = new ArrayList<>();
+        try {
+            for (SearchIndexedEntity<?> entity : searchMapping.allIndexedEntities()) {
+                var index = entity.indexManager().unwrap(ElasticsearchIndexManager.class).descriptor();
+                successfulRollovers.add(rollover(client, gson, index,
+                        mappings.get(index.hibernateSearchName()), settings.get(index.hibernateSearchName())));
+            }
+        } catch (RuntimeException | IOException e) {
+            try {
+                rollbackAll(client, gson, successfulRollovers);
+            } catch (RuntimeException e2) {
+                e.addSuppressed(e2);
+            }
+            throw new IllegalStateException("Failed to start rollover: " + e.getMessage(), e);
+        }
+        return new Rollover(client, gson, successfulRollovers);
+    }
+
+    private record IndexRolloverResult(ElasticsearchIndexDescriptor index, String oldIndex, String newIndex) {
+    }
+
+    private static RestClient client(SearchMapping searchMapping) {
+        return searchMapping.backend().unwrap(ElasticsearchBackend.class).client(RestClient.class);
+    }
+
+    private final RestClient client;
+    private final Gson gson;
+    private final List<IndexRolloverResult> indexRolloverResults;
+    private boolean done;
+
+    private Rollover(RestClient client, Gson gson, List<IndexRolloverResult> indexRolloverResults) {
+        this.client = client;
+        this.gson = gson;
+        this.indexRolloverResults = indexRolloverResults;
+    }
+
+    @Override
+    public void close() {
+        if (!done) {
+            rollback();
+        }
+    }
+
+    public void commit() {
+        commitAll(client, gson, indexRolloverResults);
+        done = true;
+    }
+
+    public void rollback() {
+        rollbackAll(client, gson, indexRolloverResults);
+        done = true;
+    }
+
+    private static IndexRolloverResult rollover(RestClient client, Gson gson, ElasticsearchIndexDescriptor index,
+            JsonObject mapping, JsonObject settings)
+            throws IOException {
+        var request = new Request("POST", "/" + index.writeName() + "/_rollover");
+        JsonObject body = new JsonObject();
+        body.add("mappings", mapping);
+        body.add("settings", settings);
+        request.setEntity(new StringEntity(gson.toJson(body), ContentType.APPLICATION_JSON));
+        var response = client.performRequest(request);
+        try (var input = response.getEntity().getContent()) {
+            var responseBody = gson.fromJson(new InputStreamReader(input, StandardCharsets.UTF_8), JsonObject.class);
+            return new IndexRolloverResult(index, responseBody.get("old_index").getAsString(),
+                    responseBody.get("new_index").getAsString());
+        }
+    }
+
+    private static void commitAll(RestClient client, Gson gson, List<IndexRolloverResult> rollovers) {
+        Log.info("Committing index rollover");
+        try {
+            changeAliasesAtomically(client, gson, rollovers, rolloverResult -> {
+                JsonObject useNewIndexAsRead = aliasAction("add", Map.of(
+                        "index", rolloverResult.newIndex,
+                        "alias", rolloverResult.index.readName()));
+                JsonObject removeOldIndex = aliasAction("remove_index", Map.of(
+                        "index", rolloverResult.oldIndex));
+                return Stream.of(useNewIndexAsRead, removeOldIndex);
+            });
+        } catch (RuntimeException | IOException e) {
+            throw new IllegalStateException("Failed to commit rollover: " + e.getMessage(), e);
+        }
+    }
+
+    private static void rollbackAll(RestClient client, Gson gson, List<IndexRolloverResult> rollovers) {
+        Log.info("Rolling back index rollover");
+        try {
+            changeAliasesAtomically(client, gson, rollovers, rolloverResult -> {
+                JsonObject restoreOldIndexAsWriteIndex = aliasAction("add", Map.of(
+                        "index", rolloverResult.oldIndex,
+                        "alias", rolloverResult.index.writeName(),
+                        "is_write_index", "true"));
+                JsonObject removeNewIndex = aliasAction("remove_index", Map.of(
+                        "index", rolloverResult.newIndex));
+                return Stream.of(restoreOldIndexAsWriteIndex, removeNewIndex);
+            });
+        } catch (RuntimeException | IOException e) {
+            throw new IllegalStateException("Failed to rollback rollover: " + e.getMessage(), e);
+        }
+    }
+
+    private static void changeAliasesAtomically(RestClient client, Gson gson, List<IndexRolloverResult> rollovers,
+            Function<IndexRolloverResult, Stream<JsonObject>> actionsFunction) throws IOException {
+        var request = new Request("POST", "_aliases");
+        JsonObject body = new JsonObject();
+        JsonArray actions = new JsonArray();
+        body.add("actions", actions);
+        rollovers.stream().flatMap(actionsFunction).forEach(actions::add);
+        request.setEntity(new StringEntity(gson.toJson(body), ContentType.APPLICATION_JSON));
+        client.performRequest(request);
+    }
+
+    private static JsonObject aliasAction(String actionName, Map<String, String> parameters) {
+        JsonObject outer = new JsonObject();
+        JsonObject inner = new JsonObject();
+        outer.add(actionName, inner);
+        parameters.forEach(inner::addProperty);
+        return outer;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,10 @@ quarkus.test.integration-test-profile=integrationtest
 ## so for tests we index data included directly in the project directory.
 %dev,test,integrationtest.fetching.quarkusio.method=local
 %dev,test,integrationtest.uris.local.default-root=${maven.test.data.path}
+quarkus.log.category."org.hibernate.search".min-level=TRACE
+%dev,test,integrationtest.quarkus.log.category."org.hibernate.search".level=INFO
+quarkus.log.category."org.elasticsearch.client".min-level=TRACE
+%dev,test,integrationtest.quarkus.log.category."org.elasticsearch.client".level=INFO
 
 # Hibernate
 quarkus.hibernate-search-orm.elasticsearch.version=8.10

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,13 +6,20 @@ fetching.quarkusio.uri=${uris.quarkusio.${fetching.quarkusio.method}}
 uris.quarkusio.git=https://github.com/quarkusio/quarkusio.github.io.git
 uris.quarkusio.local=file:${uris.local.default-root}/quarkusio
 
+# Hibernate
 ## We actually don't need persistence, it's just that Hibernate Search requires Hibernate ORM at the moment.
 ## So we just use an in-memory DB.
 quarkus.datasource.jdbc.url=jdbc:h2:mem:searchquarkusio
 quarkus.hibernate-orm.database.generation=drop-and-create
-
+## Hibernate Search
+quarkus.hibernate-search-orm.elasticsearch.version=8.10
+quarkus.elasticsearch.devservices.image-name=docker.io/elastic/elasticsearch:8.10.2
 ## We need to apply a custom Elasticsearch mapping to exclude very large fields from the _source
 quarkus.hibernate-search-orm.elasticsearch.schema-management.mapping-file=elasticsearch/mapping-template.json
+## We don't expect Elasticsearch to be reachable when the application starts
+quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false
+## ... and the application automatically creates indexes upon first indexing anyway.
+quarkus.hibernate-search-orm.schema-management.strategy=none
 
 # Dev/testing
 quarkus.test.integration-test-profile=integrationtest
@@ -24,10 +31,6 @@ quarkus.log.category."org.hibernate.search".min-level=TRACE
 %dev,test,integrationtest.quarkus.log.category."org.hibernate.search".level=INFO
 quarkus.log.category."org.elasticsearch.client".min-level=TRACE
 %dev,test,integrationtest.quarkus.log.category."org.elasticsearch.client".level=INFO
-
-# Hibernate
-quarkus.hibernate-search-orm.elasticsearch.version=8.10
-quarkus.elasticsearch.devservices.image-name=docker.io/elastic/elasticsearch:8.10.2
 
 # More secure HTTP defaults
 quarkus.http.cors=true
@@ -62,10 +65,6 @@ quarkus.swagger-ui.title=Quarkus Search API
 # Rely on OpenShift's internal DNS to resolve the IP to Elasticsearch nodes
 %prod.quarkus.hibernate-search-orm.elasticsearch.hosts=elasticsearch-0.elasticsearch:9200,elasticsearch-1.elasticsearch:9200,elasticsearch-2.elasticsearch:9200
 %prod.quarkus.hibernate-search-orm.elasticsearch.protocol=http
-## We don't expect Elasticsearch to be reachable when the application starts
-%prod.quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false
-## ... and the application automatically creates indexes upon first indexing anyway.
-%prod.quarkus.hibernate-search-orm.schema-management.strategy=none
 
 # Deployment to OpenShift
 %prod.quarkus.openshift.part-of=search-quarkus-io


### PR DESCRIPTION
The main reason for this change is to improve startup on openshift, which doesn't work well if we do a very long blocking operation in a CDI listener. So, asynchronous is better.

Zero-downtime indexing... turned out to not be necessary in the end, but will be useful eventually anyway (when we want to reindex upon Quarkus releases), so let's keep it :)