### PR TITLE
Use the correct `/version/` instead of `/versions/` in guide HTTP paths

### DIFF
--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -204,7 +204,7 @@ class SearchServiceTest {
         assertThat(result.hits())
                 .isNotEmpty()
                 .allSatisfy(hit -> assertThat(hit).extracting(SearchHit::id, InstanceOfAssertFactories.STRING)
-                        .startsWith("/versions/2.7/guides/"));
+                        .startsWith("/version/2.7/guides/"));
         result = given()
                 .queryParam("q", "orm")
                 .queryParam("version", "main")
@@ -215,7 +215,7 @@ class SearchServiceTest {
         assertThat(result.hits())
                 .isNotEmpty()
                 .allSatisfy(hit -> assertThat(hit).extracting(SearchHit::id, InstanceOfAssertFactories.STRING)
-                        .startsWith("/versions/main/guides/"));
+                        .startsWith("/version/main/guides/"));
     }
 
     @Test

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -94,7 +94,7 @@ class FetchingServiceTest {
                                             Set.of("topic1", "topic2"),
                                             Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                             FETCHED_GUIDE_1_CONTENT),
-                                    isGuide("/versions/2.7/guides/" + FETCHED_GUIDE_2_NAME,
+                                    isGuide("/version/2.7/guides/" + FETCHED_GUIDE_2_NAME,
                                             "Some other title",
                                             null,
                                             "keyword3, keyword4",


### PR DESCRIPTION
For some reason quarkus.io in its source code uses `/_versions/`, but the generated site uses `/version/`...