### PR TITLE
More flexible CORS settings

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ uris.quarkusio.local=file:${uris.local.default-root}/quarkusio
 
 # More secure HTTP defaults
 quarkus.http.cors=true
-quarkus.http.cors.origins=https://quarkus.io,/https://quarkus-website-pr-[0-9]+-preview\.surge\.sh
+quarkus.http.cors.origins=https://quarkus.io,/https://.*\.quarkus\.io/,/https://quarkus-website-pr-[0-9]+-preview\.surge\.sh
 quarkus.http.cors.methods=GET
 quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.http.header."X-Frame-Options".value=deny

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ uris.quarkusio.local=file:${uris.local.default-root}/quarkusio
 
 # More secure HTTP defaults
 quarkus.http.cors=true
-quarkus.http.cors.origins=https://quarkus.io/
+quarkus.http.cors.origins=https://quarkus.io,/https://quarkus-website-pr-[0-9]+-preview\.surge\.sh
 quarkus.http.cors.methods=GET
 quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.http.header."X-Frame-Options".value=deny


### PR DESCRIPTION
Makes it work for subdomains and surge.sh previews.

Also, it seems CORS only matches the protocol + host, so I don't think we need to account for URL paths.