### PR TITLE
Use the AND operator by default for multi-term queries

### DIFF
--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
+import org.hibernate.search.engine.search.common.BooleanOperator;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
 import org.jboss.resteasy.reactive.RestQuery;
@@ -61,7 +62,8 @@ public class SearchService {
                                 .field("title_autocomplete").boost(1.0f)
                                 .field("summary_autocomplete").boost(0.5f)
                                 .field("fullContent_autocomplete").boost(0.1f)
-                                .matching(q))
+                                .matching(q)
+                                .defaultOperator(BooleanOperator.AND))
                                 .should(f.not(f.match().field("topics").matching("compatibility"))
                                         .boost(50.0f)));
                     }

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -98,6 +98,15 @@ class SearchServiceTest {
     }
 
     @Test
+    void queryMatchingTwoTerms() {
+        var result = search("orm elasticsearch");
+        // We expect an AND by default
+        assertThat(result.hits()).extracting(SearchHit::id)
+                .containsExactlyInAnyOrder(GuideIds.HIBERNATE_SEARCH_ORM_ELASTICSEARCH);
+        assertThat(result.total()).isEqualTo(1);
+    }
+
+    @Test
     void queryEmptyString() {
         var result = search("");
         assertThat(result.hits()).extracting(SearchHit::id)


### PR DESCRIPTION
See https://github.com/quarkusio/quarkusio.github.io/pull/1825#issuecomment-1805779948

I suspect we'll come to regret this when we'll introduce more complex queries, e.g. to query both english and japanese fields, which have different analyzers and thus can't be targeted in the same predicate.

But I guess that's a problem for another day.