### PR TITLE
Enable highlighting on title/summary/fullContent

### DIFF
--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -35,13 +35,13 @@ public class SearchService {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Search for any resource")
+    @Operation(summary = "Search for Guides")
     @Transactional
     @Path("/guides/search")
     public SearchResult<GuideSearchHit> search(@RestQuery @DefaultValue(QuarkusVersions.LATEST) String version,
             @RestQuery List<String> categories,
             @RestQuery String q,
-            @RestQuery String highlightCssClass,
+            @RestQuery @DefaultValue("highlighted") String highlightCssClass,
             @RestQuery @DefaultValue("0") int page,
             @RestQuery @DefaultValue("1") int contentSnippets,
             @RestQuery @DefaultValue("100") int contentSnippetsLength) {

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -20,7 +20,7 @@ import org.hibernate.search.mapper.orm.session.SearchSession;
 
 import org.jboss.resteasy.reactive.RestQuery;
 
-import io.quarkus.search.app.dto.SearchHit;
+import io.quarkus.search.app.dto.GuideSearchHit;
 import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.entity.Guide;
 
@@ -37,7 +37,8 @@ public class SearchService {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Search for any resource")
     @Transactional
-    public SearchResult<SearchHit> search(@RestQuery @DefaultValue(QuarkusVersions.LATEST) String version,
+    @Path("/guides/search")
+    public SearchResult<GuideSearchHit> search(@RestQuery @DefaultValue(QuarkusVersions.LATEST) String version,
             @RestQuery List<String> categories,
             @RestQuery String q,
             @RestQuery String highlightCssClass,
@@ -45,7 +46,7 @@ public class SearchService {
             @RestQuery @DefaultValue("1") int contentSnippets,
             @RestQuery @DefaultValue("100") int contentSnippetsLength) {
         var result = session.search(Guide.class)
-                .select(SearchHit.class)
+                .select(GuideSearchHit.class)
                 .where((f, root) -> {
                     // Match all documents by default
                     root.add(f.matchAll());

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -13,7 +13,9 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
+import org.hibernate.Length;
 import org.hibernate.search.engine.search.common.BooleanOperator;
+import org.hibernate.search.engine.search.highlighter.dsl.HighlighterEncoder;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
 import org.jboss.resteasy.reactive.RestQuery;
@@ -38,7 +40,10 @@ public class SearchService {
     public SearchResult<SearchHit> search(@RestQuery @DefaultValue(QuarkusVersions.LATEST) String version,
             @RestQuery List<String> categories,
             @RestQuery String q,
-            @RestQuery @DefaultValue("0") int page) {
+            @RestQuery String highlightCssClass,
+            @RestQuery @DefaultValue("0") int page,
+            @RestQuery @DefaultValue("1") int contentSnippets,
+            @RestQuery @DefaultValue("100") int contentSnippetsLength) {
         var result = session.search(Guide.class)
                 .select(SearchHit.class)
                 .where((f, root) -> {
@@ -68,6 +73,22 @@ public class SearchService {
                                         .boost(50.0f)));
                     }
                 })
+                // * Highlighters are going to use spans-with-classes so that we will have more control over styling the visual on the search results screen.
+                // * We give control to the caller on the content snippet length and the number of these fragments
+                // * No match size is there to make sure that we are still going to get the text even if the field didn't have a match in it.
+                // * The title in the Guide entity is `Length.LONG` long, so we use that as a max value for no-match size, but hopefully nobody writes a title that long...
+                .highlighter(
+                        f -> f.unified().noMatchSize(Length.LONG).fragmentSize(0)
+                                .orderByScore(true)
+                                // just in case we have any "unsafe" content:
+                                .encoder(HighlighterEncoder.HTML)
+                                .numberOfFragments(1)
+                                .tag("<span class=\"" + highlightCssClass + "\">", "</span>")
+                                .boundaryScanner().sentence().end())
+                // * If there's no match in the full content we don't want to return anything.
+                // * Also content is really huge, so we want to only get small parts of the sentences. We are allowing caller to pick the number of sentences and their length:
+                .highlighter("highlighter_content",
+                        f -> f.unified().noMatchSize(0).numberOfFragments(contentSnippets).fragmentSize(contentSnippetsLength))
                 .sort(f -> f.score().then().field("title_sort"))
                 .fetch(page * PAGE_SIZE, PAGE_SIZE);
         return new SearchResult<>(result.total().hitCount(), result.hits());

--- a/src/main/java/io/quarkus/search/app/dto/GuideSearchHit.java
+++ b/src/main/java/io/quarkus/search/app/dto/GuideSearchHit.java
@@ -1,20 +1,24 @@
 package io.quarkus.search.app.dto;
 
+import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.HighlightProjection;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IdProjection;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
 
-public record SearchHit(String id, String title, String summary, Set<String> content) {
+public record GuideSearchHit(String url, String type, String origin, String title, String summary, Set<String> content) {
 
     @ProjectionConstructor
-    public SearchHit(@IdProjection String id,
+    public GuideSearchHit(@IdProjection String url,
+            @FieldProjection String type,
+            @FieldProjection String origin,
             @HighlightProjection List<String> title,
             @HighlightProjection List<String> summary,
             @HighlightProjection(highlighter = "highlighter_content") List<String> fullContent) {
-        this(id, title.get(0), summary.isEmpty() ? "" : summary.get(0), new LinkedHashSet<>(fullContent));
+        this(url, type, origin, title.get(0), summary.isEmpty() ? "" : summary.get(0), new LinkedHashSet<>(fullContent));
     }
 }

--- a/src/main/java/io/quarkus/search/app/dto/SearchHit.java
+++ b/src/main/java/io/quarkus/search/app/dto/SearchHit.java
@@ -1,9 +1,20 @@
 package io.quarkus.search.app.dto;
 
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.HighlightProjection;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IdProjection;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
 
-@ProjectionConstructor
-public record SearchHit(@IdProjection String id, @FieldProjection String title) {
+public record SearchHit(String id, String title, String summary, Set<String> content) {
+
+    @ProjectionConstructor
+    public SearchHit(@IdProjection String id,
+            @HighlightProjection List<String> title,
+            @HighlightProjection List<String> summary,
+            @HighlightProjection(highlighter = "highlighter_content") List<String> fullContent) {
+        this(id, title.get(0), summary.isEmpty() ? "" : summary.get(0), new LinkedHashSet<>(fullContent));
+    }
 }

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.hibernate.Length;
 import org.hibernate.search.engine.backend.types.Aggregable;
+import org.hibernate.search.engine.backend.types.Highlightable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
@@ -32,13 +33,13 @@ public class Guide {
     @KeywordField
     public String version;
 
-    @FullTextField
+    @FullTextField(highlightable = Highlightable.UNIFIED)
     @FullTextField(name = "title_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @KeywordField(name = "title_sort", normalizer = AnalysisConfigurer.SORT, searchable = Searchable.NO, sortable = Sortable.YES)
     @Column(length = Length.LONG)
     public String title;
 
-    @FullTextField
+    @FullTextField(highlightable = Highlightable.UNIFIED)
     @FullTextField(name = "summary_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @Column(length = Length.LONG32)
     public String summary;
@@ -48,7 +49,7 @@ public class Guide {
     @Column(length = Length.LONG32)
     public String keywords;
 
-    @FullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class))
+    @FullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.UNIFIED)
     @FullTextField(name = "fullContent_autocomplete", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @Transient
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -28,10 +28,16 @@ import jakarta.persistence.Transient;
 @Indexed
 public class Guide {
     @Id
-    public String path;
+    public String url;
 
     @KeywordField
     public String version;
+
+    @KeywordField
+    public String type;
+
+    @KeywordField
+    public String origin;
 
     @FullTextField(highlightable = Highlightable.UNIFIED)
     @FullTextField(name = "title_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
@@ -68,7 +74,7 @@ public class Guide {
     @Override
     public String toString() {
         return "Guide{" +
-                "path='" + path + '\'' +
+                "url='" + url + '\'' +
                 '}';
     }
 }

--- a/src/main/java/io/quarkus/search/app/fetching/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/fetching/QuarkusIO.java
@@ -32,6 +32,7 @@ public class QuarkusIO implements AutoCloseable {
 
     public static final String SOURCE_BRANCH = "develop";
     public static final String PAGES_BRANCH = "master";
+    private static final String QUARKUS_ORIGIN = "quarkus";
 
     public static String httpPath(String version, String name) {
         return QuarkusVersions.LATEST.equals(version) ? "/guides/" + name
@@ -100,9 +101,10 @@ public class QuarkusIO implements AutoCloseable {
     private Guide parseGuide(GuidesDirectory guidesDirectory, Path path) {
         var guide = new Guide();
         guide.version = guidesDirectory.version;
+        guide.origin = QUARKUS_ORIGIN;
         String name = FilenameUtils.removeExtension(path.getFileName().toString());
-        guide.path = httpPath(guidesDirectory.version, name);
-        guide.htmlFullContentProvider = new GitInputProvider(git, pagesTree, guide.path + ".html");
+        guide.url = httpPath(guidesDirectory.version, name);
+        guide.htmlFullContentProvider = new GitInputProvider(git, pagesTree, guide.url + ".html");
         getMetadata(guidesDirectory).accept(path, guide);
         return guide;
     }

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -183,7 +183,13 @@ public class IndexingService {
         try {
             while (docIterator.hasNext()) {
                 T doc = docIterator.next();
-                session.persist(doc);
+                try {
+                    Log.debugf("About to persist: %s", doc);
+                    session.persist(doc);
+                } catch (Exception e) {
+                    Log.errorf(e, "Failed to persist a guide: %s", doc);
+                    throw e;
+                }
 
                 ++i;
                 if (i % INDEXING_BATCH_SIZE == 0) {

--- a/src/main/java/io/quarkus/search/app/yml/QuarkusMetadata.java
+++ b/src/main/java/io/quarkus/search/app/yml/QuarkusMetadata.java
@@ -60,6 +60,7 @@ public class QuarkusMetadata {
     public void addMetadata(Path path, Guide guide) {
         Metadata metadata = this.guides.get(path.getFileName().toString());
 
+        guide.type = metadata.type();
         guide.title = metadata.title();
         guide.summary = metadata.summary();
         guide.categories = metadata.categories();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,8 @@ quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.http.header."X-Frame-Options".value=deny
 quarkus.http.header."Strict-Transport-Security".value=max-age=31536000; includeSubDomains
 
+quarkus.resteasy-reactive.path=/api
+
 # Hibernate
 ## We actually don't need persistence, it's just that Hibernate Search requires Hibernate ORM at the moment.
 ## So we just use an in-memory DB.

--- a/src/main/resources/indexes/mapping-template.json
+++ b/src/main/resources/indexes/mapping-template.json
@@ -1,7 +1,6 @@
 {
   "_source": {
     "excludes": [
-      "fullContent",
       "fullContent_autocomplete"
     ]
   }

--- a/src/main/resources/indexes/settings-template.json
+++ b/src/main/resources/indexes/settings-template.json
@@ -1,4 +1,6 @@
 {
-  "auto_expand_replicas": "0-all"
+  "auto_expand_replicas": "0-all",
+  "highlight": {
+    "max_analyzed_offset": 5000000
+  }
 }
-

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -220,11 +220,11 @@ class FetchingServiceTest {
             <p>This is the other guide body
             """;
 
-    private static Consumer<Guide> isGuide(String path, String title, String summary, String keywords,
+    private static Consumer<Guide> isGuide(String url, String title, String summary, String keywords,
             Set<String> categories, Set<String> topics, Set<String> extensions, String content) {
         return guide -> {
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(guide).extracting("path").isEqualTo(path);
+                softly.assertThat(guide).extracting("url").asString().isEqualTo(url);
                 softly.assertThat(guide).extracting("title").isEqualTo(title);
                 softly.assertThat(guide).extracting("summary").isEqualTo(summary);
                 softly.assertThat(guide).extracting("keywords").isEqualTo(keywords);

--- a/src/test/java/io/quarkus/search/app/testsupport/GuideRef.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/GuideRef.java
@@ -28,11 +28,11 @@ public record GuideRef(String name) {
         return ALL.toArray(GuideRef[]::new);
     }
 
-    public static String[] ids(GuideRef... refs) {
-        return ids(QuarkusVersions.LATEST, refs);
+    public static String[] urls(GuideRef... refs) {
+        return urls(QuarkusVersions.LATEST, refs);
     }
 
-    public static String[] ids(String version, GuideRef... refs) {
+    public static String[] urls(String version, GuideRef... refs) {
         return Arrays.stream(refs).map(g -> QuarkusIO.httpPath(version, g.name)).toArray(String[]::new);
     }
 


### PR DESCRIPTION
fixes https://github.com/quarkusio/search.quarkus.io/issues/39

I've used the unified highlighter as that is the one that Elasticsearch is maintaining on their own and have their own custom version. 
I had to remove `fullContent` field from excluded as otherwise we wouldn't be able to do highlighting on that field. Aaaand that lead to the problem as the content is really long and the search query will fail. I've increased the `max_analyzed_offset` from `1000000` to `5000000`. Alternatively, we could've use the `max_analyzed_offset` (https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#max-analyzed-offset) but we didn't add it as an exposed option 🙈 and I didn't want to get into customizing the JSON 😃.

A couple of search results:

looking for a config property `quarkus.hibernate-search-orm.enabled`:
```json
{
  "total": 2,
  "hits": [
    {
      "id": "/guides/hibernate-search-orm-elasticsearch",
      "title": "Hibernate Search guide",
      "summary": [
        "Hibernate Search allows you to index your entities in an Elasticsearch cluster and easily offer full text search in all your Hibernate ORM-based applications."
      ],
      "content": [
        "at runtime Configuration property Type Default <span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-<span class=\"highlightedContent\">orm.enabled</span> Whether Hibernate <span class=\"highlightedContent\">Search</span> is enabled during the build.",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\""
      ]
    },
    {
      "id": "/guides/all-config",
      "title": "All configuration options",
      "summary": [
        "List all the configuration properties per extensions"
      ],
      "content": [
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\"",
        "<span class=\"highlightedContent\">quarkus.hibernate</span>-<span class=\"highlightedContent\">search</span>-orm.\""
      ]
    }
  ]
}
```
looking for `hibernate search` :
```json
{
  "total": 32,
  "hits": [
    {
      "id": "/guides/hibernate-search-orm-elasticsearch",
      "title": "<span class=\"highlightedTitle\">Hibernate</span> <span class=\"highlightedTitle\">Search</span> guide",
      "summary": [
        "<span class=\"highlightedContent\">Hibernate</span> <span class=\"highlightedContent\">Search</span> allows you to index your entities in an Elasticsearch cluster and easily offer full text <span class=\"highlightedContent\">search</span> in all your <span class=\"highlightedContent\">Hibernate</span> ORM-based applications."
      ],
      "content": [
        "Will default to false in <span class=\"highlightedContent\">Hibernate</span> <span class=\"highlightedContent\">Search</span> 7.",
        "<span class=\"highlightedContent\">Search</span> guide You have a <span class=\"highlightedContent\">Hibernate</span> ORM-based application?",
        "If <span class=\"highlightedContent\">Hibernate</span> <span class=\"highlightedContent\">Search</span> is disabled during the build, all processing related to <span class=\"highlightedContent\">Hibernate</span> <span class=\"highlightedContent\">Search</span> will be skipped, but it will not be possible to activate <span class=\"highlightedContent\">Hibernate</span>",
        "Let’s see how you can do it with <span class=\"highlightedContent\">Hibernate</span> <span class=\"highlightedContent\">Search</span>.",
        "\\\n    -Dextensions='<span class=\"highlightedContent\">hibernate</span>-orm-panache,jdbc-postgresql,<span class=\"highlightedContent\">hibernate</span>-<span class=\"highlightedContent\">search</span>-orm-elasticsearch,resteasy-reactive-jackson' \\\n    -DnoCode\ncd <span class=\"highlightedContent\">hibernate</span>-<span class=\"highlightedContent\">search</span>-orm-elasticsearch-quickstart"
      ]
    },
    {
      "id": "/guides/hibernate-orm-panache",
      "title": "Simplified <span class=\"highlightedTitle\">Hibernate</span> ORM with Panache",
      "summary": [
        "<span class=\"highlightedContent\">Hibernate</span> ORM is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper."
      ],
      "content": [
        "-- <span class=\"highlightedContent\">Hibernate</span> ORM specific dependencies -->\n<dependency>\n    <groupId>io.quarkus</groupId>\n    <artifactId>quarkus-<span class=\"highlightedContent\">hibernate</span>-orm-panache</artifactId>\n</",
        "The solution is located in the <span class=\"highlightedContent\">hibernate</span>-orm-panache-quickstart directory.",
        "<span class=\"highlightedContent\">Hibernate</span> ORM with Panache focuses on making your entities trivial and fun to write in Quarkus.",
        "That’s all there is to it: with Panache, <span class=\"highlightedContent\">Hibernate</span> ORM has never looked so trim and neat.",
        "<span class=\"highlightedContent\">Hibernate</span> with Panache also allows for the use of the more classical repository pattern via PanacheRepository."
      ]
    }
  ]
}
```