### PR TITLE
Convert the summary that may be written in markdown before indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,21 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.jgit</groupId>
+        <artifactId>quarkus-jgit</artifactId>
+        <version>3.0.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonmark</groupId>
+        <artifactId>commonmark</artifactId>
+        <version>0.21.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.16.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -92,7 +107,6 @@
     <dependency>
       <groupId>io.quarkiverse.jgit</groupId>
       <artifactId>quarkus-jgit</artifactId>
-      <version>3.0.5</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -113,7 +127,10 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.16.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -15,7 +15,6 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 
 import org.hibernate.Length;
 import org.hibernate.search.engine.search.common.BooleanOperator;
-import org.hibernate.search.engine.search.highlighter.dsl.HighlighterEncoder;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
 import org.jboss.resteasy.reactive.RestQuery;
@@ -82,8 +81,6 @@ public class SearchService {
                 .highlighter(
                         f -> f.unified().noMatchSize(Length.LONG).fragmentSize(0)
                                 .orderByScore(true)
-                                // just in case we have any "unsafe" content:
-                                .encoder(HighlighterEncoder.HTML)
                                 .numberOfFragments(1)
                                 .tag("<span class=\"" + highlightCssClass + "\">", "</span>")
                                 .boundaryScanner().sentence().end())

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -18,6 +18,7 @@ import org.hibernate.search.engine.backend.types.Highlightable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.TermVector;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
@@ -44,13 +45,13 @@ public class Guide {
     @KeywordField
     public String origin;
 
-    @FullTextField(highlightable = Highlightable.UNIFIED)
+    @FullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS)
     @FullTextField(name = "title_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @KeywordField(name = "title_sort", normalizer = AnalysisConfigurer.SORT, searchable = Searchable.NO, sortable = Sortable.YES)
     @Column(length = Length.LONG)
     public String title;
 
-    @FullTextField(highlightable = Highlightable.UNIFIED)
+    @FullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS)
     @FullTextField(name = "summary_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @Column(length = Length.LONG32)
     public String summary;

--- a/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
@@ -16,10 +16,12 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
     public void configure(ElasticsearchAnalysisConfigurationContext context) {
         context.analyzer(DEFAULT).custom()
                 .tokenizer("standard")
-                .tokenFilters("lowercase", "asciifolding", "stemmer");
+                .tokenFilters("lowercase", "asciifolding", "stemmer")
+                .charFilters("html_strip");
         context.analyzer(AUTOCOMPLETE).custom()
                 .tokenizer("standard")
-                .tokenFilters("lowercase", "asciifolding", "stemmer", "autocomplete_edge_ngram");
+                .tokenFilters("lowercase", "asciifolding", "stemmer", "autocomplete_edge_ngram")
+                .charFilters("html_strip");
         context.tokenFilter("autocomplete_edge_ngram")
                 .type("edge_ngram")
                 .param("min_gram", 1)

--- a/src/main/java/io/quarkus/search/app/hibernate/InputProviderHtmlBodyTextBridge.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/InputProviderHtmlBodyTextBridge.java
@@ -21,20 +21,59 @@ public class InputProviderHtmlBodyTextBridge implements ValueBridge<InputProvide
             Element content = body.selectFirst(".content .grid__item");
             if (content != null) {
                 // Means we've found a guide content column. hence let's use that to have only real content:
-                return content.text();
+                return encode(content);
             } else {
                 // we might be looking at a quarkiverse guide; in such case:
                 content = body.selectFirst("article.doc");
                 if (content != null) {
                     // Means we've found a guide content column. hence let's use that to have only real content:
-                    return content.text();
+                    return encode(content);
                 } else {
-                    Log.warnf("Was unable to find the content section of a guide. Using whole document as text. %s", provider);
-                    return body.text();
+                    Log.warnf(
+                            "Was unable to find the content section of a guide. Using whole document as text. %s",
+                            provider);
+                    return encode(body);
                 }
             }
         } catch (RuntimeException | IOException e) {
             throw new IllegalStateException("Failed to read '" + provider + "' for indexing: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * We want to encode the guide content before indexing to make it safe to return on search results
+     * and do not worry about encoding it on each search response.
+     */
+    private static String encode(Element element) {
+        String input = element.text();
+        StringBuilder result = new StringBuilder(input.length());
+
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            switch (ch) {
+                case '"':
+                    result.append("&quot;");
+                    break;
+                case '&':
+                    result.append("&amp;");
+                    break;
+                case '\'':
+                    result.append("&#x27;");
+                    break;
+                case '/':
+                    result.append("&#x2F;");
+                    break;
+                case '<':
+                    result.append("&lt;");
+                    break;
+                case '>':
+                    result.append("&gt;");
+                    break;
+                default:
+                    result.append(ch);
+            }
+        }
+
+        return result.toString();
     }
 }

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -1,5 +1,7 @@
 package io.quarkus.search.app.quarkusio;
 
+import static io.quarkus.search.app.util.MarkdownRenderer.renderMarkdown;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -213,10 +215,10 @@ public class QuarkusIO implements AutoCloseable {
             String summaryKey) {
         Guide guide = new Guide();
         guide.type = type;
-        guide.title = toString(parsedGuide.get("title"));
-        guide.summary = toString(parsedGuide.get(summaryKey));
+        guide.title = renderMarkdown(toString(parsedGuide.get("title")));
         guide.origin = toString(parsedGuide.get("origin"));
         guide.version = version;
+        guide.summary = renderMarkdown(toString(parsedGuide.get(summaryKey)));
         String parsedUrl = toString(parsedGuide.get("url"));
         URI uri;
         if (parsedUrl.startsWith("http")) {

--- a/src/main/java/io/quarkus/search/app/util/MarkdownRenderer.java
+++ b/src/main/java/io/quarkus/search/app/util/MarkdownRenderer.java
@@ -1,0 +1,55 @@
+package io.quarkus.search.app.util;
+
+import java.util.Set;
+
+import org.commonmark.node.Node;
+import org.commonmark.node.Paragraph;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.Renderer;
+import org.commonmark.renderer.html.HtmlNodeRendererContext;
+import org.commonmark.renderer.html.HtmlRenderer;
+
+public final class MarkdownRenderer {
+
+    private MarkdownRenderer() {
+    }
+
+    private static final Renderer RENDERER = HtmlRenderer.builder().nodeRendererFactory(
+            ParagraphToBrNodeRenderer::new).build();
+    private static final Parser MARKDOWN_PARSER = Parser.builder().build();
+
+    public static String renderMarkdown(String markdown) {
+        if (markdown == null) {
+            return null;
+        }
+        return RENDERER.render(MARKDOWN_PARSER.parse(markdown)).trim();
+    }
+
+    private static class ParagraphToBrNodeRenderer implements NodeRenderer {
+        private final HtmlNodeRendererContext context;
+
+        public ParagraphToBrNodeRenderer(HtmlNodeRendererContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public Set<Class<? extends Node>> getNodeTypes() {
+            return Set.of(Paragraph.class);
+        }
+
+        @Override
+        public void render(Node paragraph) {
+            Node node = paragraph.getFirstChild();
+            while (node != null) {
+                Node next = node.getNext();
+                context.render(node);
+                node = next;
+            }
+            if (paragraph.getNext() != null) {
+                context.getWriter().tag("br/");
+            }
+
+        }
+    }
+}

--- a/src/test/java/io/quarkus/search/app/util/ParserTest.java
+++ b/src/test/java/io/quarkus/search/app/util/ParserTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.search.app.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ParserTest {
+    @Test
+    void renderingOfMarkdown() {
+        assertThat(MarkdownRenderer.renderMarkdown("some text"))
+                .isEqualTo("some text");
+        assertThat(MarkdownRenderer.renderMarkdown("some text\n\nmore text"))
+                .isEqualTo("some text<br/>more text");
+        assertThat(MarkdownRenderer.renderMarkdown(
+                "Quarkus DI solution is based on the [Jakarta Contexts and Dependency Injection 4.0](https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html) specification."))
+                .isEqualTo(
+                        "Quarkus DI solution is based on the <a href=\"https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html\">Jakarta Contexts and Dependency Injection 4.0</a> specification.");
+    }
+
+}


### PR DESCRIPTION
fixes https://github.com/quarkusio/search.quarkus.io/issues/60

Not sure which library you had in mind to render the summaries, so I tried `commonmark`.  Simple rendering of HTML doesn't produce great results, since we have the HTML encoder applied for highlights. that means that the returned text cannot be easily inserted into the page. Also, since the highlighter is applied to the "source" we will still get the link path highlighted, making things worse 😄.

A couple of options that we have:

* using an HTML renderer, will produce (just to show what we are ending up with...):
```html
&lt;p&gt;Quarkus DI solution is based on the &lt;a href=&quot;https:&#x2F;&#x2F;jakarta.ee&#x2F;specifications&#x2F;<span class=\"highlighted\">cdi</span>&#x2F;4.0&#x2F;jakarta-<span class=\"highlighted\">cdi</span>-spec-4.0.html&quot;&gt;Jakarta Contexts and Dependency Injection 4.0&lt;&#x2F;a&gt; specification."
```
That is not really fine since the URL is all "highlighted". Additionally, we are encoding html with a highlighter so this isn't really renderable on the UI ... 

* Using a text renderer as in this PR, resulting in :
```html
"Quarkus DI solution is based on the &quot;Jakarta Contexts and Dependency Injection 4.0&quot; (https:&#x2F;&#x2F;jakarta.ee&#x2F;specifications&#x2F;<span class=\"highlighted\">cdi</span>&#x2F;4.0&#x2F;jakarta-<span class=\"highlighted\">cdi</span>-spec-4.0.html) specification."
```
This at least, will render somewhat OK on the UI, and the link will be there for the user, though not clickable, and its parts will be "highlighted"

* use an HTML renderer -> apply Jsoup to parse the rendered HTML -> extract the "text only",  `guide.summary = Jsoup.parse(markdownRenderer.render(markdownParser.parse(summary))).text();` resulting in:
```html
"Quarkus DI solution is based on the Jakarta Contexts and Dependency Injection 4.0 specification."
```

* Just ask not to use markdown in the summaries 😏 😄 😉 