### PR TITLE
WIP: Localized sites support

### DIFF
--- a/src/main/java/io/quarkus/search/app/dto/GuideSearchHit.java
+++ b/src/main/java/io/quarkus/search/app/dto/GuideSearchHit.java
@@ -5,20 +5,21 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.HighlightProjection;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IdProjection;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
-
 public record GuideSearchHit(URI url, String type, String origin, String title, String summary, Set<String> content) {
 
-    @ProjectionConstructor
-    public GuideSearchHit(@IdProjection URI url,
-            @FieldProjection String type,
-            @FieldProjection String origin,
-            @HighlightProjection List<String> title,
-            @HighlightProjection List<String> summary,
-            @HighlightProjection(highlighter = "highlighter_content") List<String> fullContent) {
+    public GuideSearchHit(URI url,
+            String type,
+            String origin,
+            List<String> title,
+            List<String> summary,
+            List<String> fullContent) {
         this(url, type, origin, title.get(0), summary.isEmpty() ? "" : summary.get(0), new LinkedHashSet<>(fullContent));
+    }
+
+    @SuppressWarnings("unchecked")
+    public GuideSearchHit(List<?> values) {
+        this(
+                (URI) values.get(0), (String) values.get(1), (String) values.get(2),
+                (List<String>) values.get(3), (List<String>) values.get(4), (List<String>) values.get(5));
     }
 }

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -1,9 +1,14 @@
 package io.quarkus.search.app.entity;
 
+import io.quarkus.search.app.hibernate.I18nFullTextField;
+import io.quarkus.search.app.hibernate.I18nKeywordField;
 import io.quarkus.search.app.hibernate.InputProvider;
 import io.quarkus.search.app.hibernate.InputProviderHtmlBodyTextBridge;
+import io.quarkus.search.app.hibernate.Localization;
 import io.quarkus.search.app.hibernate.URIType;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
@@ -45,27 +50,54 @@ public class Guide {
     @KeywordField
     public String origin;
 
-    @FullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS)
-    @FullTextField(name = "title_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
-    @KeywordField(name = "title_sort", normalizer = AnalysisConfigurer.SORT, searchable = Searchable.NO, sortable = Sortable.YES)
-    @Column(length = Length.LONG)
-    public String title;
+    @I18nFullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS, localization = {
+            @Localization(language = "en"),
+            @Localization(language = "es"),
+            @Localization(language = "ja")
+    })
+    @I18nFullTextField(name = "title_autocomplete", localization = {
+            @Localization(language = "en", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT),
+            @Localization(language = "es", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT),
+            @Localization(language = "ja", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
+    })
+    @I18nKeywordField(name = "title_sort", normalizer = AnalysisConfigurer.SORT, searchable = Searchable.NO, sortable = Sortable.YES, languages = {
+            "en", "es", "ja" })
+    @Embedded
+    @AttributeOverride(name = "data", column = @Column(length = Length.LONG, name = "title"))
+    public I18nData<String> title;
 
-    @FullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS)
-    @FullTextField(name = "summary_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
-    @Column(length = Length.LONG32)
-    public String summary;
+    @I18nFullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS, localization = {
+            @Localization(language = "en"),
+            @Localization(language = "es"),
+            @Localization(language = "ja")
+    })
+    @I18nFullTextField(name = "summary_autocomplete", localization = {
+            @Localization(language = "en", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT),
+            @Localization(language = "es", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT),
+            @Localization(language = "ja", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
+    })
+    @Embedded
+    @AttributeOverride(name = "data", column = @Column(length = Length.LONG32, name = "summary"))
+    public I18nData<String> summary;
 
     @FullTextField
     @FullTextField(name = "keywords_autocomplete", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @Column(length = Length.LONG32)
     public String keywords;
 
-    @FullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.UNIFIED)
-    @FullTextField(name = "fullContent_autocomplete", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
     @Transient
+    @I18nFullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.UNIFIED, localization = {
+            @Localization(language = "en"),
+            @Localization(language = "es"),
+            @Localization(language = "ja")
+    })
+    @I18nFullTextField(name = "fullContent_autocomplete", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), localization = {
+            @Localization(language = "en", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT),
+            @Localization(language = "es", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT),
+            @Localization(language = "ja", analyzer = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzer = AnalysisConfigurer.DEFAULT)
+    })
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
-    public InputProvider htmlFullContentProvider;
+    public I18nData<InputProvider> htmlFullContentProvider;
 
     @KeywordField(name = "categories")
     public Set<String> categories = Set.of();

--- a/src/main/java/io/quarkus/search/app/entity/I18nData.java
+++ b/src/main/java/io/quarkus/search/app/entity/I18nData.java
@@ -1,0 +1,39 @@
+package io.quarkus.search.app.entity;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class I18nData<T> {
+    @JdbcTypeCode(SqlTypes.JSON)
+    Map<String, T> data = new LinkedHashMap<>();
+
+    public I18nData() {
+    }
+
+    public I18nData(T data) {
+        add("en", data);
+    }
+
+    public I18nData<T> add(String language, T value) {
+        data.put(language, value);
+        return this;
+    }
+
+    public T get(String language) {
+        return data.get(language);
+    }
+
+    public T get(String language, String fallbackLanguage) {
+        T t = data.get(language);
+        if (t == null) {
+            return data.get(fallbackLanguage);
+        }
+        return t;
+    }
+}

--- a/src/main/java/io/quarkus/search/app/hibernate/AbstractI18nTextFieldPropertyMappingAnnotationProcessor.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/AbstractI18nTextFieldPropertyMappingAnnotationProcessor.java
@@ -1,0 +1,84 @@
+package io.quarkus.search.app.hibernate;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingFieldOptionsStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+
+import io.quarkus.search.app.entity.I18nData;
+
+public abstract class AbstractI18nTextFieldPropertyMappingAnnotationProcessor<A extends Annotation, S>
+        implements PropertyMappingAnnotationProcessor<A> {
+    @Override
+    public void process(PropertyMappingStep propertyMappingStep, A annotation,
+            PropertyMappingAnnotationProcessorContext processorContext) {
+        String name = name(annotation);
+        if ("".equals(name)) {
+            name = processorContext.annotatedElement().name();
+        }
+
+        String fallbackLanguage = fallbackLanguage(annotation);
+        ValueBridgeRef valueBridgeRef = valueBridge(annotation);
+
+        for (S language : languages(annotation)) {
+
+            PropertyMappingFieldOptionsStep<?> fieldContext = initFieldMappingContext(language, propertyMappingStep, annotation,
+                    name);
+
+            ValueBridge delegate;
+            if (ValueBridgeRef.UndefinedBridgeImplementationType.class.equals(valueBridgeRef.type())) {
+                // no bridge so we just want a value
+                delegate = (str, ctx) -> str;
+            } else {
+                delegate = bridgeDelegate(valueBridgeRef);
+            }
+            fieldContext.valueBridge(new I18nDataBridge(delegate, stringRepresentation(language), fallbackLanguage));
+        }
+    }
+
+    protected abstract PropertyMappingFieldOptionsStep<?> initFieldMappingContext(S language,
+            PropertyMappingStep propertyMappingStep, A annotation, String name);
+
+    protected abstract S[] languages(A annotation);
+
+    protected abstract String stringRepresentation(S language);
+
+    protected abstract ValueBridgeRef valueBridge(A annotation);
+
+    protected abstract String fallbackLanguage(A annotation);
+
+    abstract String name(A annotation);
+
+    private static ValueBridge bridgeDelegate(ValueBridgeRef valueBridgeRef) {
+        try {
+            return valueBridgeRef.type().getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class I18nDataBridge implements ValueBridge<I18nData, String> {
+        private final ValueBridge<Object, String> delegate;
+        private final String language;
+        private final String fallbackLanguage;
+
+        private I18nDataBridge(ValueBridge<Object, String> delegate, String language, String fallbackLanguage) {
+            this.delegate = delegate;
+            this.language = language;
+            this.fallbackLanguage = fallbackLanguage;
+        }
+
+        @Override
+        public String toIndexedValue(I18nData data, ValueBridgeToIndexedValueContext ctx) {
+            Object o = data.get(language, fallbackLanguage);
+            return delegate.toIndexedValue(o, ctx);
+        }
+    }
+
+}

--- a/src/main/java/io/quarkus/search/app/hibernate/I18nFullTextField.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/I18nFullTextField.java
@@ -1,0 +1,44 @@
+package io.quarkus.search.app.hibernate;
+
+import static io.quarkus.search.app.hibernate.I18nFullTextField.List;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.engine.backend.types.Highlightable;
+import org.hibernate.search.engine.backend.types.TermVector;
+import org.hibernate.search.engine.environment.bean.BeanRetrieval;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
+
+@Documented
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(List.class)
+@PropertyMapping(processor = @PropertyMappingAnnotationProcessorRef(type = I18nFullTextFieldPropertyMappingAnnotationProcessor.class, retrieval = BeanRetrieval.CONSTRUCTOR))
+public @interface I18nFullTextField {
+
+    String name() default "";
+
+    Highlightable[] highlightable() default { Highlightable.DEFAULT };
+
+    TermVector termVector() default TermVector.DEFAULT;
+
+    ValueBridgeRef valueBridge() default @ValueBridgeRef;
+
+    String fallbackLanguage() default "en";
+
+    Localization[] localization();
+
+    @Documented
+    @Target({ ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface List {
+        I18nFullTextField[] value();
+    }
+}

--- a/src/main/java/io/quarkus/search/app/hibernate/I18nFullTextFieldPropertyMappingAnnotationProcessor.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/I18nFullTextFieldPropertyMappingAnnotationProcessor.java
@@ -1,0 +1,63 @@
+package io.quarkus.search.app.hibernate;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.hibernate.search.engine.backend.types.Highlightable;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.TermVector;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingFieldOptionsStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingFullTextFieldOptionsStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+
+public class I18nFullTextFieldPropertyMappingAnnotationProcessor
+        extends AbstractI18nTextFieldPropertyMappingAnnotationProcessor<I18nFullTextField, Localization> {
+    @Override
+    protected PropertyMappingFieldOptionsStep<?> initFieldMappingContext(Localization localization,
+            PropertyMappingStep propertyMappingStep, I18nFullTextField annotation, String name) {
+        PropertyMappingFullTextFieldOptionsStep step = propertyMappingStep
+                .fullTextField("%s_%s".formatted(name, localization.language()))
+                .projectable(Projectable.YES).analyzer(localization.analyzer());
+
+        if (!localization.searchAnalyzer().isEmpty()) {
+            step.searchAnalyzer(localization.searchAnalyzer());
+        }
+
+        TermVector termVector = annotation.termVector();
+        if (!TermVector.DEFAULT.equals(termVector)) {
+            step.termVector(termVector);
+        }
+        Highlightable[] highlightable = annotation.highlightable();
+        if (!(highlightable.length == 1 && Highlightable.DEFAULT.equals(highlightable[0]))) {
+            step.highlightable(
+                    highlightable.length == 0 ? Collections.emptyList() : Arrays.asList(highlightable));
+        }
+        return step;
+    }
+
+    @Override
+    protected Localization[] languages(I18nFullTextField annotation) {
+        return annotation.localization();
+    }
+
+    @Override
+    protected String stringRepresentation(Localization localization) {
+        return localization.language();
+    }
+
+    @Override
+    protected ValueBridgeRef valueBridge(I18nFullTextField annotation) {
+        return annotation.valueBridge();
+    }
+
+    @Override
+    protected String fallbackLanguage(I18nFullTextField annotation) {
+        return annotation.fallbackLanguage();
+    }
+
+    @Override
+    String name(I18nFullTextField annotation) {
+        return annotation.name();
+    }
+}

--- a/src/main/java/io/quarkus/search/app/hibernate/I18nKeywordField.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/I18nKeywordField.java
@@ -1,0 +1,46 @@
+package io.quarkus.search.app.hibernate;
+
+import static io.quarkus.search.app.hibernate.I18nKeywordField.List;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.engine.backend.types.Searchable;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.environment.bean.BeanRetrieval;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
+
+@Documented
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(List.class)
+@PropertyMapping(processor = @PropertyMappingAnnotationProcessorRef(type = I18nKeywordFieldPropertyMappingAnnotationProcessor.class, retrieval = BeanRetrieval.CONSTRUCTOR))
+public @interface I18nKeywordField {
+
+    String name() default "";
+
+    String normalizer() default "";
+
+    Searchable searchable() default Searchable.DEFAULT;
+
+    Sortable sortable() default Sortable.DEFAULT;
+
+    ValueBridgeRef valueBridge() default @ValueBridgeRef;
+
+    String fallbackLanguage() default "en";
+
+    String[] languages();
+
+    @Documented
+    @Target({ ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface List {
+        I18nKeywordField[] value();
+    }
+}

--- a/src/main/java/io/quarkus/search/app/hibernate/I18nKeywordFieldPropertyMappingAnnotationProcessor.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/I18nKeywordFieldPropertyMappingAnnotationProcessor.java
@@ -1,0 +1,59 @@
+package io.quarkus.search.app.hibernate;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Searchable;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingFieldOptionsStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingKeywordFieldOptionsStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+
+public class I18nKeywordFieldPropertyMappingAnnotationProcessor
+        extends AbstractI18nTextFieldPropertyMappingAnnotationProcessor<I18nKeywordField, String> {
+    @Override
+    protected PropertyMappingFieldOptionsStep<?> initFieldMappingContext(String language,
+            PropertyMappingStep propertyMappingStep, I18nKeywordField annotation, String name) {
+        PropertyMappingKeywordFieldOptionsStep step = propertyMappingStep.keywordField("%s_%s".formatted(name, language))
+                .projectable(Projectable.YES);
+        String normalizer = annotation.normalizer();
+        if (!normalizer.isEmpty()) {
+            step.normalizer(annotation.normalizer());
+        }
+        Sortable sortable = annotation.sortable();
+        if (!Sortable.DEFAULT.equals(sortable)) {
+            step.sortable(sortable);
+        }
+
+        Searchable searchable = annotation.searchable();
+        if (!Searchable.DEFAULT.equals(searchable)) {
+            step.searchable(searchable);
+        }
+
+        return step;
+    }
+
+    @Override
+    protected String[] languages(I18nKeywordField annotation) {
+        return annotation.languages();
+    }
+
+    @Override
+    protected String stringRepresentation(String language) {
+        return language;
+    }
+
+    @Override
+    protected ValueBridgeRef valueBridge(I18nKeywordField annotation) {
+        return annotation.valueBridge();
+    }
+
+    @Override
+    protected String fallbackLanguage(I18nKeywordField annotation) {
+        return annotation.fallbackLanguage();
+    }
+
+    @Override
+    String name(I18nKeywordField annotation) {
+        return annotation.name();
+    }
+}

--- a/src/main/java/io/quarkus/search/app/hibernate/Localization.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/Localization.java
@@ -1,0 +1,18 @@
+package io.quarkus.search.app.hibernate;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Localization {
+
+    String language();
+
+    String analyzer() default "default";
+
+    String searchAnalyzer() default "";
+}

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.hibernate.search.util.common.impl.Closer;
 
+import io.quarkus.search.app.entity.I18nData;
 import io.quarkus.search.app.util.CloseableDirectory;
 import io.quarkus.search.app.util.GitInputProvider;
 import io.quarkus.search.app.util.GitUtils;
@@ -215,23 +216,30 @@ public class QuarkusIO implements AutoCloseable {
             String summaryKey) {
         Guide guide = new Guide();
         guide.type = type;
-        guide.title = renderMarkdown(toString(parsedGuide.get("title")));
+        String title = renderMarkdown(toString(parsedGuide.get("title")));
+        guide.title = new I18nData<>(title)
+                .add("es", title)
+                .add("ja", title);
         guide.origin = toString(parsedGuide.get("origin"));
         guide.version = version;
-        guide.summary = renderMarkdown(toString(parsedGuide.get(summaryKey)));
+        String summary = renderMarkdown(toString(parsedGuide.get(summaryKey)));
+        guide.summary = new I18nData<>(summary)
+                .add("es", summary)
+                .add("ja", summary);
+        ;
         String parsedUrl = toString(parsedGuide.get("url"));
         URI uri;
         if (parsedUrl.startsWith("http")) {
             // we are looking at a quarkiverse guide:
             uri = httpUrl(version, parsedUrl);
-            guide.htmlFullContentProvider = new UrlInputProvider(prefetchedQuarkiverseGuides, uri);
+            guide.htmlFullContentProvider = new I18nData<>(new UrlInputProvider(prefetchedQuarkiverseGuides, uri));
 
             if (guide.origin == null) {
                 guide.origin = QUARKIVERSE_ORIGIN;
             }
         } else {
             uri = httpUrl(webUri, version, parsedUrl);
-            guide.htmlFullContentProvider = new GitInputProvider(git, pagesTree, htmlPath(version, parsedUrl));
+            guide.htmlFullContentProvider = new I18nData<>(new GitInputProvider(git, pagesTree, htmlPath(version, parsedUrl)));
 
             if (guide.origin == null) {
                 guide.origin = QUARKUS_ORIGIN;

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIOConfig.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIOConfig.java
@@ -1,7 +1,10 @@
 package io.quarkus.search.app.quarkusio;
 
 import java.net.URI;
+import java.util.Map;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -14,4 +17,15 @@ public interface QuarkusIOConfig {
 
     @WithDefault(WEB_URI_DEFAULT_STRING)
     URI webUri();
+
+    @ConfigDocSection
+    @ConfigDocMapKey("language")
+    Map<String, SiteConfig> localized();
+
+    interface SiteConfig {
+        URI gitUri();
+
+        URI webUri();
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@ quarkus.application.name=search-quarkus-io
 
 # Application defaults
 quarkusio.git-uri=https://github.com/quarkusio/quarkusio.github.io.git
+quarkusio.localized."ja".git-uri=https://github.com/quarkusio/ja.quarkusio.io.git
+quarkusio.localized."ja".web-uri=https://ja.quarkus.io/
 
 # More secure HTTP defaults
 quarkus.http.cors=true

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.quarkus.search.app.entity.I18nData;
 import jakarta.inject.Inject;
 
 import org.apache.commons.io.file.PathUtils;
@@ -185,8 +186,10 @@ class FetchingServiceTest {
         return guide -> {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(guide).extracting("url").asString().isEqualTo(url);
-                softly.assertThat(guide).extracting("title").isEqualTo(title);
-                softly.assertThat(guide).extracting("summary").isEqualTo(summary);
+                softly.assertThat(guide).extracting("title", InstanceOfAssertFactories.type(I18nData.class))
+                        .extracting(d -> d.get("en")).isEqualTo(title);
+                softly.assertThat(guide).extracting("summary", InstanceOfAssertFactories.type(I18nData.class))
+                        .extracting(d -> d.get("en")).isEqualTo(summary);
                 softly.assertThat(guide).extracting("keywords").isEqualTo(keywords);
                 softly.assertThat(guide).extracting("categories", InstanceOfAssertFactories.COLLECTION)
                         .containsExactlyInAnyOrderElementsOf(categories);
@@ -195,7 +198,8 @@ class FetchingServiceTest {
                 softly.assertThat(guide).extracting("extensions", InstanceOfAssertFactories.COLLECTION)
                         .containsExactlyInAnyOrderElementsOf(extensions);
                 softly.assertThat(guide)
-                        .extracting("htmlFullContentProvider", InstanceOfAssertFactories.type(InputProvider.class))
+                        .extracting("htmlFullContentProvider", InstanceOfAssertFactories.type(I18nData.class))
+                        .extracting(d -> d.get("en"), InstanceOfAssertFactories.type(InputProvider.class))
                         .extracting(uncheckedIO(InputProvider::open), InstanceOfAssertFactories.INPUT_STREAM)
                         .hasContent(content);
             });


### PR DESCRIPTION
Hey Yoann,

This is just an early WIP PR so we can see some code examples 😃. It's just about the entity and indexing for now, I haven't reached the parsing of translations yet. But from what I can see so far, we'd need to have differernt URLs for differet languages. That means that either we wrap the url in the same container and introduce some generic id (number or uuid), or we go back to the relative urls for these guides and prepend the host part to search results based on the language... 

Also I went with the map and list for languages, since the site has 5 languages already, so I thought it would make more sense rather than having 5 specific fields.

Does what you see make sense, or should I explore other options before moving to parsing part ?