### PR TITLE
Add plugin to sort/remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>
     <version.formatter.plugin>2.23.0</version.formatter.plugin>
+    <version.impsort-maven-plugin>1.9.0</version.impsort-maven-plugin>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -236,6 +237,28 @@
           <lineEnding>LF</lineEnding>
           <skip>${format.skip}</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code</groupId>
+        <artifactId>impsort-maven-plugin</artifactId>
+        <version>${version.impsort-maven-plugin}</version>
+        <configuration>
+          <groups>java.,javax.,jakarta.,io.quarkus.search.,io.quarkus.,org.hibernate.,org.junit.,org.,com.,*</groups>
+          <staticGroups>*</staticGroups>
+          <!-- To make static imports go on top: -->
+          <staticAfter>false</staticAfter>
+          <skip>${format.skip}</skip>
+          <removeUnused>true</removeUnused>
+        </configuration>
+        <executions>
+          <execution>
+            <id>import-sorting</id>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <phase>process-sources</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -11,18 +11,17 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.openapi.annotations.Operation;
+import io.quarkus.search.app.dto.GuideSearchHit;
+import io.quarkus.search.app.dto.SearchResult;
+import io.quarkus.search.app.entity.Guide;
 
 import org.hibernate.Length;
 import org.hibernate.search.engine.search.common.BooleanOperator;
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryFlag;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.resteasy.reactive.RestQuery;
-
-import io.quarkus.search.app.dto.GuideSearchHit;
-import io.quarkus.search.app.dto.SearchResult;
-import io.quarkus.search.app.entity.Guide;
 
 @ApplicationScoped
 @Path("/")

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -1,15 +1,18 @@
 package io.quarkus.search.app.entity;
 
-import io.quarkus.search.app.hibernate.InputProvider;
-import io.quarkus.search.app.hibernate.InputProviderHtmlBodyTextBridge;
-import io.quarkus.search.app.hibernate.URIType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-
 import java.net.URI;
 import java.util.Objects;
 import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+
+import io.quarkus.search.app.hibernate.AnalysisConfigurer;
+import io.quarkus.search.app.hibernate.InputProvider;
+import io.quarkus.search.app.hibernate.InputProviderHtmlBodyTextBridge;
+import io.quarkus.search.app.hibernate.URIType;
 
 import org.hibernate.Length;
 import org.hibernate.annotations.JavaType;
@@ -25,9 +28,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextFi
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
-
-import io.quarkus.search.app.hibernate.AnalysisConfigurer;
-import jakarta.persistence.Transient;
 
 @Entity
 @Indexed

--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -5,22 +5,23 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 
-import io.quarkus.search.app.quarkusio.QuarkusIO;
-import io.quarkus.search.app.quarkusio.QuarkusIOConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import io.quarkus.search.app.quarkusio.QuarkusIO;
+import io.quarkus.search.app.quarkusio.QuarkusIOConfig;
+import io.quarkus.search.app.util.CloseableDirectory;
+import io.quarkus.search.app.util.FileUtils;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.LaunchMode;
+
+import org.hibernate.search.util.common.impl.SuppressingCloser;
 
 import org.apache.commons.io.function.IOBiFunction;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.TextProgressMonitor;
-
-import org.hibernate.search.util.common.impl.SuppressingCloser;
-
-import io.quarkus.logging.Log;
-import io.quarkus.runtime.LaunchMode;
-import io.quarkus.search.app.util.CloseableDirectory;
-import io.quarkus.search.app.util.FileUtils;
 
 @ApplicationScoped
 public class FetchingService {

--- a/src/main/java/io/quarkus/search/app/health/IndexContentHealthCheck.java
+++ b/src/main/java/io/quarkus/search/app/health/IndexContentHealthCheck.java
@@ -4,12 +4,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 import org.eclipse.microprofile.health.Startup;
-
-import org.hibernate.search.mapper.orm.session.SearchSession;
 
 /**
  * Checks that the indexes were populated.

--- a/src/main/java/io/quarkus/search/app/health/IndexSchemaHealthCheck.java
+++ b/src/main/java/io/quarkus/search/app/health/IndexSchemaHealthCheck.java
@@ -4,12 +4,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 import org.eclipse.microprofile.health.Startup;
-
-import org.hibernate.search.mapper.orm.session.SearchSession;
 
 /**
  * Checks that the indexes have the correct schema.

--- a/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
@@ -1,9 +1,9 @@
 package io.quarkus.search.app.hibernate;
 
+import io.quarkus.hibernate.search.orm.elasticsearch.SearchExtension;
+
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-
-import io.quarkus.hibernate.search.orm.elasticsearch.SearchExtension;
 
 @SearchExtension
 public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {

--- a/src/main/java/io/quarkus/search/app/hibernate/InputProviderHtmlBodyTextBridge.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/InputProviderHtmlBodyTextBridge.java
@@ -3,10 +3,11 @@ package io.quarkus.search.app.hibernate;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import io.quarkus.logging.Log;
+
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
 
-import io.quarkus.logging.Log;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 

--- a/src/main/java/io/quarkus/search/app/hibernate/URIType.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/URIType.java
@@ -2,13 +2,13 @@ package io.quarkus.search.app.hibernate;
 
 import java.net.URI;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.AbstractClassJavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * A Hibernate ORM {@link org.hibernate.type.descriptor.java.JavaType} for {@link URI}.

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -9,20 +9,22 @@ import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RestClient;
+import io.quarkus.search.app.fetching.FetchingService;
+import io.quarkus.search.app.quarkusio.QuarkusIO;
+
+import io.quarkus.logging.Log;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.vertx.http.ManagementInterface;
 
 import org.hibernate.Session;
 import org.hibernate.search.backend.elasticsearch.ElasticsearchBackend;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.util.common.impl.Closer;
 
-import io.quarkus.logging.Log;
-import io.quarkus.narayana.jta.QuarkusTransaction;
-import io.quarkus.runtime.StartupEvent;
-import io.quarkus.search.app.fetching.FetchingService;
-import io.quarkus.search.app.quarkusio.QuarkusIO;
-import io.quarkus.vertx.http.ManagementInterface;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;

--- a/src/main/java/io/quarkus/search/app/indexing/Rollover.java
+++ b/src/main/java/io/quarkus/search/app/indexing/Rollover.java
@@ -16,10 +16,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RestClient;
+import io.quarkus.logging.Log;
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchBackend;
 import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
@@ -28,11 +25,14 @@ import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDe
 import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-
-import io.quarkus.logging.Log;
 
 /**
  * Implementation of a rollover,

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -19,15 +19,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.hibernate.search.util.common.impl.Closer;
-
+import io.quarkus.search.app.QuarkusVersions;
+import io.quarkus.search.app.entity.Guide;
 import io.quarkus.search.app.util.CloseableDirectory;
 import io.quarkus.search.app.util.GitInputProvider;
 import io.quarkus.search.app.util.GitUtils;
 import io.quarkus.search.app.util.UrlInputProvider;
 
-import io.quarkus.search.app.QuarkusVersions;
-import io.quarkus.search.app.entity.Guide;
+import org.hibernate.search.util.common.impl.Closer;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.yaml.snakeyaml.Yaml;

--- a/src/main/java/io/quarkus/search/app/util/GitInputProvider.java
+++ b/src/main/java/io/quarkus/search/app/util/GitInputProvider.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import io.quarkus.search.app.hibernate.InputProvider;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.revwalk.RevTree;
 

--- a/src/main/java/io/quarkus/search/app/util/UncheckedIOFunction.java
+++ b/src/main/java/io/quarkus/search/app/util/UncheckedIOFunction.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.function.Function;
 
-import org.apache.commons.io.function.IOSupplier;
-
 @FunctionalInterface
 public interface UncheckedIOFunction<T, R> extends Function<T, R> {
     static <T, R> Function<T, R> uncheckedIO(UncheckedIOFunction<T, R> uncheckedIoFunction) {

--- a/src/main/java/io/quarkus/search/app/util/UrlInputProvider.java
+++ b/src/main/java/io/quarkus/search/app/util/UrlInputProvider.java
@@ -10,8 +10,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import io.quarkus.logging.Log;
 import io.quarkus.search.app.hibernate.InputProvider;
+
+import io.quarkus.logging.Log;
 
 public class UrlInputProvider implements InputProvider {
 

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -12,9 +12,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.ThrowingConsumer;
-import org.awaitility.Awaitility;
+import io.quarkus.search.app.dto.GuideSearchHit;
+import io.quarkus.search.app.dto.SearchResult;
+import io.quarkus.search.app.testsupport.GuideRef;
+import io.quarkus.search.app.testsupport.QuarkusIOSample;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,12 +27,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.quarkus.search.app.dto.GuideSearchHit;
-import io.quarkus.search.app.dto.SearchResult;
-import io.quarkus.search.app.testsupport.GuideRef;
-import io.quarkus.search.app.testsupport.QuarkusIOSample;
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ThrowingConsumer;
+import org.awaitility.Awaitility;
+
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.filter.log.LogDetail;

--- a/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
@@ -8,21 +8,24 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.search.app.dto.GuideSearchHit;
+import io.quarkus.search.app.dto.SearchResult;
+import io.quarkus.search.app.testsupport.QuarkusIOSample;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.quarkus.search.app.dto.GuideSearchHit;
-import io.quarkus.search.app.dto.SearchResult;
-import io.quarkus.search.app.testsupport.QuarkusIOSample;
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
+import org.awaitility.Awaitility;
+
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.filter.log.LogDetail;
-import org.awaitility.Awaitility;
 
 @QuarkusTest
 @TestHTTPEndpoint(SearchService.class)

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -11,24 +11,25 @@ import java.util.function.Consumer;
 
 import jakarta.inject.Inject;
 
-import org.apache.commons.io.file.PathUtils;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.SoftAssertions;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.revwalk.RevCommit;
+import io.quarkus.search.app.entity.Guide;
+import io.quarkus.search.app.hibernate.InputProvider;
+import io.quarkus.search.app.quarkusio.QuarkusIO;
+import io.quarkus.search.app.testsupport.GitTestUtils;
+import io.quarkus.search.app.util.CloseableDirectory;
+
+import io.quarkus.test.component.QuarkusComponentTestExtension;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.search.app.entity.Guide;
-import io.quarkus.search.app.hibernate.InputProvider;
-import io.quarkus.search.app.quarkusio.QuarkusIO;
-import io.quarkus.search.app.testsupport.GitTestUtils;
-import io.quarkus.search.app.util.CloseableDirectory;
-import io.quarkus.test.component.QuarkusComponentTestExtension;
+import org.apache.commons.io.file.PathUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.revwalk.RevCommit;
 
 class FetchingServiceTest {
 

--- a/src/test/java/io/quarkus/search/app/indexing/RolloverTest.java
+++ b/src/test/java/io/quarkus/search/app/indexing/RolloverTest.java
@@ -12,8 +12,12 @@ import java.util.stream.Collectors;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RestClient;
+import io.quarkus.search.app.entity.Guide;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchBackend;
 import org.hibernate.search.backend.elasticsearch.index.ElasticsearchIndexManager;
@@ -26,13 +30,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import com.google.gson.Gson;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
 
-import io.quarkus.narayana.jta.QuarkusTransaction;
-import io.quarkus.search.app.entity.Guide;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
+import com.google.gson.Gson;
 
 @QuarkusTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/io/quarkus/search/app/testsupport/GitCopier.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/GitCopier.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.quarkus.search.app.util.GitUtils;
+
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;

--- a/src/test/java/io/quarkus/search/app/testsupport/GitTestUtils.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/GitTestUtils.java
@@ -3,7 +3,6 @@ package io.quarkus.search.app.testsupport;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.util.SystemReader;
-
 import org.jboss.logging.Logger;
 
 public final class GitTestUtils {

--- a/src/test/java/io/quarkus/search/app/testsupport/QuarkusIOSample.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/QuarkusIOSample.java
@@ -24,18 +24,19 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.quarkus.search.app.QuarkusVersions;
 import io.quarkus.search.app.quarkusio.QuarkusIO;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Repository;
+import io.quarkus.search.app.util.CloseableDirectory;
+import io.quarkus.search.app.util.FileUtils;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 
-import io.quarkus.search.app.QuarkusVersions;
-import io.quarkus.search.app.util.CloseableDirectory;
-import io.quarkus.search.app.util.FileUtils;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.yaml.snakeyaml.Yaml;
 


### PR DESCRIPTION
I keep missing an import here and there, so I thought that maybe we should add the imports plugin to the build as well since we already have the code-formatter one...