### PR TITLE
Update CORS rules to allow new URL of quarkus.io previews

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkusio.git-uri=https://github.com/quarkusio/quarkusio.github.io.git
 
 # More secure HTTP defaults
 quarkus.http.cors=true
-quarkus.http.cors.origins=https://quarkus.io,/https://.*\.quarkus\.io/,/https://quarkus-website-pr-[0-9]+-preview\.surge\.sh/
+quarkus.http.cors.origins=https://quarkus.io,/https://.*\.quarkus\.io/,/https://quarkus-(web)?site-pr-[0-9]+-preview\.surge\.sh/
 quarkus.http.cors.methods=GET
 quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.http.header."X-Frame-Options".value=deny


### PR DESCRIPTION
https://quarkus-website-pr-1825-preview.surge.sh/guides/ has become https://quarkus-site-pr-1825-preview.surge.sh/guides/, no idea why.