### PR TITLE
Allow for (very) slow app startup due to cloning many large git repositories

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,8 +108,9 @@ quarkus.openshift.resources.requests.cpu=0.5
 quarkus.openshift.resources.limits.memory=500M
 quarkus.openshift.resources.requests.memory=200M
 # Initial indexing may take a while, especially the quarkus.io Git cloning
-quarkus.openshift.startup-probe.period=10S
-quarkus.openshift.startup-probe.failure-threshold=15
+quarkus.openshift.startup-probe.initial-delay=30S
+quarkus.openshift.startup-probe.period=15S
+quarkus.openshift.startup-probe.failure-threshold=20
 # Declare the management port on the service
 quarkus.openshift.ports."management".container-port=9000
 quarkus.openshift.ports."management".host-port=90

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -113,3 +113,6 @@ quarkus.openshift.startup-probe.failure-threshold=15
 # Declare the management port on the service
 quarkus.openshift.ports."management".container-port=9000
 quarkus.openshift.ports."management".host-port=90
+# Don't use the version in (service) selectors,
+# otherwise a rollback to an earlier version (due to failing startup) makes the service unavailable
+quarkus.openshift.add-version-to-label-selectors=false


### PR DESCRIPTION
Currently, deployment is failing on staging because indexing takes longer than allowed by the startup probe.

See also #90 