### PR TITLE
Enable routing by version + language

### DIFF
--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -15,6 +15,7 @@ import io.quarkus.search.app.dto.GuideSearchHit;
 import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.entity.Guide;
 import io.quarkus.search.app.entity.Language;
+import io.quarkus.search.app.entity.VersionAndLanguageRoutingBinder;
 
 import org.hibernate.Length;
 import org.hibernate.search.engine.search.common.BooleanOperator;
@@ -59,10 +60,6 @@ public class SearchService {
                     // Match all documents by default
                     root.add(f.matchAll());
 
-                    root.add(f.match().field("version").matching(version));
-
-                    root.add(f.match().field("language").matching(language));
-
                     if (categories != null && !categories.isEmpty()) {
                         root.add(f.terms().field("categories").matchingAny(categories));
                     }
@@ -103,6 +100,7 @@ public class SearchService {
                 .highlighter("highlighter_content",
                         f -> f.unified().noMatchSize(0).numberOfFragments(contentSnippets).fragmentSize(contentSnippetsLength))
                 .sort(f -> f.score().then().field("title_sort"))
+                .routing(VersionAndLanguageRoutingBinder.key(version, language))
                 .fetch(page * PAGE_SIZE, PAGE_SIZE);
         return new SearchResult<>(result.total().hitCount(), result.hits());
     }

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -29,13 +29,14 @@ import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.TermVector;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.AlternativeDiscriminator;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderRef;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 @Entity
-@Indexed
+@Indexed(routingBinder = @RoutingBinderRef(type = VersionAndLanguageRoutingBinder.class))
 public class Guide {
     @Id
     @JavaType(URIType.class)
@@ -43,10 +44,8 @@ public class Guide {
 
     @AlternativeDiscriminator
     @Enumerated(EnumType.STRING)
-    @KeywordField
     public Language language;
 
-    @KeywordField
     public String version;
 
     @KeywordField

--- a/src/main/java/io/quarkus/search/app/entity/VersionAndLanguageRoutingBinder.java
+++ b/src/main/java/io/quarkus/search/app/entity/VersionAndLanguageRoutingBinder.java
@@ -1,0 +1,38 @@
+package io.quarkus.search.app.entity;
+
+import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.RoutingBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingBinder;
+import org.hibernate.search.mapper.pojo.bridge.runtime.RoutingBridgeRouteContext;
+import org.hibernate.search.mapper.pojo.route.DocumentRoutes;
+
+public class VersionAndLanguageRoutingBinder implements RoutingBinder {
+    public static String key(String version, Language language) {
+        return version + "/" + language.code;
+    }
+
+    @Override
+    public void bind(RoutingBindingContext context) {
+        context.dependencies()
+                .use("version")
+                .use("language");
+
+        context.bridge(Guide.class, new GuideRoutingBridge());
+    }
+
+    public static class GuideRoutingBridge implements RoutingBridge<Guide> {
+
+        @Override
+        public void route(DocumentRoutes routes, Object entityIdentifier, Guide entity,
+                RoutingBridgeRouteContext context) {
+            routes.addRoute().routingKey(key(entity.version, entity.language));
+        }
+
+        @Override
+        public void previousRoutes(DocumentRoutes routes, Object entityIdentifier, Guide entity,
+                RoutingBridgeRouteContext context) {
+            // The route never changes
+            route(routes, entityIdentifier, entity, context);
+        }
+    }
+}

--- a/src/main/resources/indexes/settings-template.json
+++ b/src/main/resources/indexes/settings-template.json
@@ -2,5 +2,6 @@
   "auto_expand_replicas": "0-all",
   "highlight": {
     "max_analyzed_offset": 5000000
-  }
+  },
+  "number_of_shards": 32
 }

--- a/src/main/resources/indexes/settings-template.json
+++ b/src/main/resources/indexes/settings-template.json
@@ -2,6 +2,5 @@
   "auto_expand_replicas": "0-all",
   "highlight": {
     "max_analyzed_offset": 5000000
-  },
-  "number_of_shards": 32
+  }
 }


### PR DESCRIPTION
Not sure we should merge this, as performance didn't improve (see https://docs.google.com/spreadsheets/d/1w0tSfL-MKFArSrB-L8IX1pxmrhWmQyNgNwQRloG3cLk/edit#gid=456110917)

Maybe we should just keep the routing part (because it simplifies queries a bit) and drop the sharding config?