### PR TITLE
Avoid closing (and losing) the DB after some inactivity

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,9 @@ quarkus.resteasy-reactive.path=/api
 # Hibernate
 ## We actually don't need persistence, it's just that Hibernate Search requires Hibernate ORM at the moment.
 ## So we just use an in-memory DB.
-quarkus.datasource.jdbc.url=jdbc:h2:mem:searchquarkusio
+## Note DB_CLOSE_DELAY is necessary to avoid the DB stopping and being cleared
+## after some inactivity; see https://github.com/quarkusio/search.quarkus.io/issues/100
+quarkus.datasource.jdbc.url=jdbc:h2:mem:searchquarkusio;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.database.generation=drop-and-create
 ## Hibernate Search
 quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.11


### PR DESCRIPTION
Fixes #100 (I think)

We only use the DB when indexing, so it's very likely the DB will not be used for hours, and we don't want H2 to close it automatically, because then we'll lose all schemas.