### PR TITLE
Add validation to search endpoint query parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
     <revision>999-SNAPSHOT</revision>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
+    <test.jvm.args>-Xms2g -Xmx2g</test.jvm.args>
+    <version.docker.plugin>0.43.4</version.docker.plugin>
     <version.formatter.plugin>2.23.0</version.formatter.plugin>
     <version.impsort-maven-plugin>1.9.0</version.impsort-maven-plugin>
-    <version.docker.plugin>0.43.4</version.docker.plugin>
-    <test.jvm.args>-Xms2g -Xmx2g</test.jvm.args>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -150,6 +150,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
@@ -259,28 +263,36 @@
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
         <version>${version.impsort-maven-plugin}</version>
+        <executions>
+          <execution>
+            <id>import-sorting</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <groups>java.,javax.,jakarta.,io.quarkus.search.,io.quarkus.,org.hibernate.,org.junit.,org.,com.,*</groups>
           <staticGroups>*</staticGroups>
-          <!-- To make static imports go on top: -->
           <staticAfter>false</staticAfter>
           <skip>${format.skip}</skip>
           <removeUnused>true</removeUnused>
         </configuration>
-        <executions>
-          <execution>
-            <id>import-sorting</id>
-            <goals>
-              <goal>sort</goal>
-            </goals>
-            <phase>process-sources</phase>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${version.docker.plugin}</version>
+        <executions>
+          <execution>
+            <id>build</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <images>
             <image>
@@ -294,15 +306,6 @@
             </image>
           </images>
         </configuration>
-        <executions>
-          <execution>
-            <id>build</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>build</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -5,25 +5,29 @@ import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import io.quarkus.search.app.dto.GuideSearchHit;
-import io.quarkus.search.app.dto.SearchResult;
-import io.quarkus.search.app.entity.Guide;
-import io.quarkus.search.app.entity.Language;
-import io.quarkus.search.app.entity.VersionAndLanguageRoutingBinder;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 import org.hibernate.Length;
 import org.hibernate.search.engine.search.common.BooleanOperator;
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryFlag;
 import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.validator.constraints.Range;
 
-import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.search.app.dto.GuideSearchHit;
+import io.quarkus.search.app.dto.SearchResult;
+import io.quarkus.search.app.entity.Guide;
+import io.quarkus.search.app.entity.Language;
+import io.quarkus.search.app.entity.VersionAndLanguageRoutingBinder;
 
 @ApplicationScoped
 @Path("/")
@@ -44,9 +48,9 @@ public class SearchService {
             @RestQuery String q,
             @RestQuery @DefaultValue("en") Language language,
             @RestQuery @DefaultValue("highlighted") String highlightCssClass,
-            @RestQuery @DefaultValue("0") int page,
-            @RestQuery @DefaultValue("1") int contentSnippets,
-            @RestQuery @DefaultValue("100") int contentSnippetsLength) {
+            @RestQuery @DefaultValue("0") @Min(0) int page,
+            @RestQuery @DefaultValue("1") @Range(min = 0, max = 10) int contentSnippets,
+            @RestQuery @DefaultValue("100") @Range(min = 0, max = 200) int contentSnippetsLength) {
         var result = session.search(Guide.class)
                 .select(f -> f.composite().from(
                         f.id(),

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -327,7 +327,7 @@ class SearchServiceTest {
     }
 
     @Test
-    void highlightTitle() {
+    void highlight_title() {
         var result = given()
                 .queryParam("q", "orm")
                 .queryParam("highlightCssClass", "highlighted")
@@ -342,7 +342,7 @@ class SearchServiceTest {
     }
 
     @Test
-    void highlightSummary() {
+    void highlight_summary() {
         var result = given()
                 .queryParam("q", "orm")
                 .queryParam("highlightCssClass", "highlighted-summary")
@@ -357,7 +357,7 @@ class SearchServiceTest {
     }
 
     @Test
-    void highlightContent() {
+    void highlight_content() {
         var result = given()
                 .queryParam("q", "orm")
                 .queryParam("highlightCssClass", "highlighted-content")
@@ -373,6 +373,30 @@ class SearchServiceTest {
                 .allSatisfy(content -> assertThat(content).hasSize(1)
                         .allSatisfy(hitsHaveCorrectWordHighlighted(matches, "orm", "highlighted-content")));
         assertThat(matches.get()).isEqualTo(8);
+    }
+
+    @Test
+    void highlight_content_tooManySnippets() {
+        given()
+                .queryParam("q", "orm")
+                .queryParam("highlightCssClass", "highlighted-content")
+                .queryParam("contentSnippets", "11")
+                .queryParam("contentSnippetsLength", "50")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void highlight_content_snippetsLengthTooHigh() {
+        given()
+                .queryParam("q", "orm")
+                .queryParam("highlightCssClass", "highlighted-content")
+                .queryParam("contentSnippets", "2")
+                .queryParam("contentSnippetsLength", "201")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(400);
     }
 
     @Test


### PR DESCRIPTION
In particular for highlighting, which could perform badly with high numbers of snippets or high snippet length.