### PR TITLE
Accept quotes for phrase matching in a query

### DIFF
--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -80,8 +80,9 @@ public class SearchService {
                                 .field(localizedField("fullContent_autocomplete", language)).boost(0.1f)
                                 .matching(q)
                                 // See: https://github.com/elastic/elasticsearch/issues/39905#issuecomment-471578025
-                                // while the issue is about stopwords the same problem is observed for synonyms on search-analyzer side:
-                                .flags(SimpleQueryFlag.AND, SimpleQueryFlag.OR)
+                                // while the issue is about stopwords the same problem is observed for synonyms on search-analyzer side.
+                                // we also add phrase flag so that entire phrases could be searched as well, e.g.: "hibernate search"
+                                .flags(SimpleQueryFlag.AND, SimpleQueryFlag.OR, SimpleQueryFlag.PHRASE)
                                 .defaultOperator(BooleanOperator.AND))
                                 .should(f.match().field("origin").matching("quarkus").boost(50.0f))
                                 .should(f.not(f.match().field(localizedField("topics", language)).matching("compatibility"))

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -428,6 +428,20 @@ class SearchServiceTest {
                         "<span class=\"highlighted\">Duplicated</span> <span class=\"highlighted\">context</span>, <span class=\"highlighted\">context</span> <span class=\"highlighted\">locals</span>, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> and <span class=\"highlighted\">propagation</span>");
     }
 
+    @Test
+    void searchForPhrase() {
+        var result = given()
+                .queryParam("q", "\"asynchronous processing and propagation\"")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+        assertThat(result.hits()).extracting(GuideSearchHit::title)
+                .contains(
+                        // unified highlighter will still "highlight" the phrase word by word:
+                        "Duplicated context, context locals, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> and <span class=\"highlighted\">propagation</span>");
+    }
+
     private static ThrowingConsumer<String> hitsHaveCorrectWordHighlighted(AtomicInteger matches, String word,
             String cssClass) {
         return sentence -> {


### PR DESCRIPTION
it seems like it worked fine 😃 
Note that the highlighted text still has each word wrapped on its own. We can try switching to a fast vector highlighter, which should be able to better wrap a few words in the same tags, but unless we reallyyyyyy need that I'd stay on a unified one 😃 