### PR TITLE
Skip translated Quarkus guides that do not have an HTML in a git repository

### DIFF
--- a/src/main/java/io/quarkus/search/app/util/GitInputProvider.java
+++ b/src/main/java/io/quarkus/search/app/util/GitInputProvider.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 
 import io.quarkus.search.app.hibernate.InputProvider;
 
+import io.quarkus.logging.Log;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.revwalk.RevTree;
 
@@ -22,6 +24,15 @@ public class GitInputProvider implements InputProvider {
     @Override
     public InputStream open() throws IOException {
         return GitUtils.file(git.getRepository(), tree, path);
+    }
+
+    public boolean isFileAvailable() {
+        try {
+            return GitUtils.fileExists(git.getRepository(), tree, path);
+        } catch (IOException e) {
+            Log.warn("A problem occurred while trying to find a file in git tree: " + e.getMessage(), e);
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/io/quarkus/search/app/util/GitUtils.java
+++ b/src/main/java/io/quarkus/search/app/util/GitUtils.java
@@ -44,4 +44,12 @@ public final class GitUtils {
         ObjectLoader loader = repo.open(objectId);
         return loader.openStream();
     }
+
+    public static boolean fileExists(Repository repo, RevTree tree, String path) throws IOException {
+        TreeWalk treeWalk = new TreeWalk(repo);
+        treeWalk.addTree(tree);
+        treeWalk.setRecursive(true);
+        treeWalk.setFilter(PathFilter.create(path));
+        return treeWalk.next();
+    }
 }


### PR DESCRIPTION
It can happen, and so it did 😃, that some guide HTML file is not here in a localized repository. Currently, this would result in an exception, and the entire indexing thing will fail. But since the HTML is not there, it means the user won't be able to open it anyway, so there is no point in displaying such a record in the guide search results. And we can just ignore persisting such guide entity.