### PR TITLE
Set volume claim size to 5GiB

### DIFF
--- a/src/main/kubernetes/openshift.yml
+++ b/src/main/kubernetes/openshift.yml
@@ -227,7 +227,7 @@ spec:
         storageClassName: "gp2"
         resources:
           requests:
-            storage: 512Gi
+            storage: 5Gi
   triggers:
     - type: ConfigChange
     - type: ImageChange


### PR DESCRIPTION
The last change to that size was supposed to set it to 512MiB but mistakenly set it to 512GiB... which is way too much.

Currently we only use ~500MB per index, and this will rise to ~1GB per index after #117, so 5GiB should be more than enough and leave room for changes to analysis config and indexing of more content in the foreseable future.