### PR TITLE
Limit parallelism of indexing

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,11 +14,16 @@ quarkusio.localized.ja.git-uri=https://github.com/quarkusio/ja.quarkus.io.git
 # Indexing configuration
 fetching.parallelism=8
 fetching.timeout=10m
-indexing.parallelism=10
-indexing.batch-size=100
 indexing.timeout=5m
-# Index at 19:00:00 every day
+## Index at 19:00:00 every day
 indexing.scheduled.cron=0 0 19 * * ?
+## Indexing parallelism: we want many small batches here,
+## so that a given batch is likely to be handled in a small number
+## of bulk requests to Elasticsearch, making it unlikely that an indexing queue
+## will be empty in the middle of indexing.
+## See quarkus.hibernate-search-orm.elasticsearch.indexing below.
+indexing.parallelism=80
+indexing.batch-size=10
 
 # More secure HTTP defaults
 quarkus.http.cors=true
@@ -40,6 +45,11 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 ## Hibernate Search
 quarkus.hibernate-search-orm.elasticsearch.version=opensearch:2.11
 quarkus.elasticsearch.devservices.image-name=opensearch-custom-plugin:2.11.0
+## Limit parallelism of indexing, because OpenSearch can only handle so many pending indexing requests.
+## This leads to at most 6*40=240 documents being indexed in parallel, which should be plenty
+## given how large our documents can be.
+quarkus.hibernate-search-orm.elasticsearch.indexing.queue-count=6
+quarkus.hibernate-search-orm.elasticsearch.indexing.max-bulk-size=40
 ## We need to apply a custom OpenSearch mapping to exclude very large fields from the _source
 quarkus.hibernate-search-orm.elasticsearch.schema-management.mapping-file=indexes/mapping-template.json
 quarkus.hibernate-search-orm.elasticsearch.schema-management.settings-file=indexes/settings-template.json


### PR DESCRIPTION
Because OpenSearch can only handle so many pending indexing requests, and it's been failing to handle some of them in the staging/prod environments.