### PR TITLE
Keep git clones on disk and update them instead of re-cloning on each reindexing

### DIFF
--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -117,8 +117,8 @@ public class FetchingService {
             repository = new GitCloneDirectory.GitDirectoryDetails(cloneDir.path(), branches.pages());
             repositories.put(requestedGitUri, repository);
 
-            // If we have a local repository -- just open it, clone it otherwise:
-            return requiresCloning ? repository.clone(gitUri, branches) : repository.open();
+            // If we have a local repository -- open it, and then pull the changes, clone it otherwise:
+            return requiresCloning ? repository.clone(gitUri, branches) : repository.open().update(branches);
         } catch (RuntimeException | IOException e) {
             new SuppressingCloser(e).push(cloneDir);
             throw new IllegalStateException("Failed to fetch '%s': %s".formatted(siteName, e.getMessage()), e);

--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -5,12 +5,11 @@ import static io.quarkus.search.app.util.FileUtils.unzip;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PreDestroy;
@@ -30,6 +29,8 @@ import io.quarkus.runtime.LaunchMode;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 
+import io.vertx.core.impl.ConcurrentHashSet;
+
 @ApplicationScoped
 public class FetchingService {
 
@@ -39,8 +40,8 @@ public class FetchingService {
     @Inject
     QuarkusIOConfig quarkusIOConfig;
 
-    private final Map<URI, GitCloneDirectory.Details> detailsCache = new HashMap<>();
-    private final Set<CloseableDirectory> tempDirectories = new HashSet<>();
+    private final Map<URI, GitCloneDirectory.Details> detailsCache = new ConcurrentHashMap<>();
+    private final Set<CloseableDirectory> tempDirectories = new ConcurrentHashSet<>();
 
     public QuarkusIO fetchQuarkusIo() {
         CompletableFuture<GitCloneDirectory> main = null;

--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -89,7 +89,7 @@ public class FetchingService {
                 if (repository != null) {
                     // We are working with a zip file, so we have nothing to refresh as there's no actual remote available;
                     //   just return the same repository without any changes:
-                    return repository.open();
+                    return repository.open(branches.sources());
                 }
 
                 Log.warnf("Unzipping '%s': this application is most likely indexing only a sample of %s."
@@ -118,7 +118,7 @@ public class FetchingService {
             repositories.put(requestedGitUri, repository);
 
             // If we have a local repository -- open it, and then pull the changes, clone it otherwise:
-            return requiresCloning ? repository.clone(gitUri, branches) : repository.open().update(branches);
+            return requiresCloning ? repository.clone(gitUri, branches) : repository.open(branches.sources()).update(branches);
         } catch (RuntimeException | IOException e) {
             new SuppressingCloser(e).push(cloneDir);
             throw new IllegalStateException("Failed to fetch '%s': %s".formatted(siteName, e.getMessage()), e);

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -99,8 +99,8 @@ public class QuarkusIO implements AutoCloseable {
     @Override
     public void close() throws Exception {
         try (var closer = new Closer<Exception>()) {
-            closer.push(GitCloneDirectory::close, mainRepository);
             closer.push(CloseableDirectory::close, prefetchedQuarkiverseGuides);
+            closer.push(GitCloneDirectory::close, mainRepository);
             closer.pushAll(GitCloneDirectory::close, localizedSites.values());
         }
     }
@@ -113,7 +113,7 @@ public class QuarkusIO implements AutoCloseable {
     // guides based on the info from the _data/versioned/[version]/index/
     // may contain quarkus.yaml as well as quarkiverse.yml
     private Stream<Guide> versionedGuides() throws IOException {
-        return Files.list(mainRepository.directory().path().resolve("_data").resolve("versioned"))
+        return Files.list(mainRepository.resolve("_data").resolve("versioned"))
                 .flatMap(p -> {
                     var version = p.getFileName().toString().replace('-', '.');
                     Path quarkiverse = p.resolve("index").resolve("quarkiverse.yaml");
@@ -143,13 +143,13 @@ public class QuarkusIO implements AutoCloseable {
 
     private static Path resolveTranslationPath(String version, String filename, GitCloneDirectory directory,
             Language language) {
-        return directory.directory().path().resolve(
+        return directory.resolve(
                 Path.of("l10n", "po", language.locale, "_data", "versioned", version, "index", filename + ".po"));
     }
 
     // older version guides like guides-2-7.yaml or guides-2-13.yaml
     private Stream<Guide> legacyGuides() throws IOException {
-        return Files.list(mainRepository.directory().path().resolve("_data"))
+        return Files.list(mainRepository.resolve("_data"))
                 .filter(p -> !Files.isDirectory(p) && p.getFileName().toString().startsWith("guides-"))
                 .flatMap(p -> {
                     var version = p.getFileName().toString().replaceAll("guides-|\\.yaml", "").replace('-', '.');
@@ -164,7 +164,7 @@ public class QuarkusIO implements AutoCloseable {
     }
 
     private static Path resolveLegacyTranslationPath(String filename, GitCloneDirectory directory, Language language) {
-        return directory.directory().path().resolve(
+        return directory.resolve(
                 Path.of("l10n", "po", language.locale, "_data", filename + ".po"));
     }
 

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -275,7 +275,7 @@ public class QuarkusIO implements AutoCloseable {
                         if (!gitInputProvider.isFileAvailable()) {
                             // if  a file is not present we do not want to add such guide. Since if the html is not there
                             // it means that users won't be able to open it on the site, and returning it in the search results make it pointless.
-                            Log.warn("Guide " + guide
+                            Log.warn("Guide " + translated
                                     + " is ignored since we were not able to find an HTML content file for it.");
                             return null;
                         }

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -43,10 +43,10 @@ public class QuarkusIO implements AutoCloseable {
 
     public static final String QUARKUS_ORIGIN = "quarkus";
     private static final String QUARKIVERSE_ORIGIN = "quarkiverse";
-    public static final String SOURCE_BRANCH = "develop";
-    public static final String PAGES_BRANCH = "master";
-    public static final String LOCALIZED_SOURCE_BRANCH = "main";
-    public static final String LOCALIZED_PAGES_BRANCH = "docs";
+    public static final GitCloneDirectory.Branches MAIN_BRANCHES = new GitCloneDirectory.Branches(
+            "develop", "master");
+    public static final GitCloneDirectory.Branches LOCALIZED_BRANCHES = new GitCloneDirectory.Branches(
+            "main", "docs");
 
     public static URI httpUrl(URI urlBase, String version, String name) {
         return urlBase.resolve(httpPath(version, name));

--- a/src/main/java/io/quarkus/search/app/util/CloseableDirectory.java
+++ b/src/main/java/io/quarkus/search/app/util/CloseableDirectory.java
@@ -36,4 +36,11 @@ public final class CloseableDirectory implements Closeable {
         return path;
     }
 
+    @Override
+    public String toString() {
+        return "CloseableDirectory{" +
+                "path=" + path +
+                ", shouldDelete=" + shouldDelete +
+                '}';
+    }
 }

--- a/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
+++ b/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
@@ -4,7 +4,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import io.quarkus.search.app.fetching.FetchingService;
 import io.quarkus.search.app.fetching.LoggerProgressMonitor;
@@ -17,12 +19,12 @@ import org.hibernate.search.util.common.impl.SuppressingCloser;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevTree;
-import org.eclipse.jgit.transport.RemoteConfig;
 import org.jboss.logging.Logger;
 
 public class GitCloneDirectory implements Closeable {
 
     private static final Logger log = Logger.getLogger(GitCloneDirectory.class);
+    private static final List<String> ORDERED_REMOTES = Arrays.asList("origin", "upstream");
     private final Git git;
 
     private final GitDirectoryDetails directory;
@@ -56,20 +58,37 @@ public class GitCloneDirectory implements Closeable {
     public RevTree pagesTree() {
         if (this.pagesTree == null) {
             try {
-                String remote;
-                List<RemoteConfig> remotes = git.remoteList().call();
+                String remote = null;
+                Set<String> remotes = git.getRepository().getRemoteNames();
                 if (remotes.isEmpty()) {
                     remote = "";
                 } else {
-                    remote = remotes.get(0).getName() + "/";
+                    for (String name : ORDERED_REMOTES) {
+                        if (remotes.contains(name)) {
+                            remote = name + "/";
+                        }
+                    }
+                    if (remote == null) {
+                        log.warn(
+                                "Wasn't able to find any of the default/expected remotes (%s) so a random existing one will be picked. Indexing results are not guaranteed to be correct."
+                                        .formatted(ORDERED_REMOTES));
+                        // If at this point we still haven't figured out the remote ... then we probably are going to fail anyway,
+                        //  but let's give it one more chance and just pick any of the remotes at random.
+                        remote = remotes.iterator().next() + "/";
+                    }
                 }
 
                 this.pagesTree = GitUtils.firstExistingRevTree(git.getRepository(), remote + directory.pagesBranch());
-            } catch (GitAPIException | IOException e) {
+            } catch (IOException e) {
                 throw new RuntimeException("Unable to locate pages branch: " + directory.pagesBranch(), e);
             }
         }
         return pagesTree;
+    }
+
+    public GitCloneDirectory update(FetchingService.Branches branches) {
+        directory.pull(git, branches);
+        return this;
     }
 
     @Override
@@ -98,6 +117,17 @@ public class GitCloneDirectory implements Closeable {
             Git git = null;
             try {
                 git = Git.open(directory.toFile());
+                pull(git, branches);
+                return new GitCloneDirectory(git, this);
+            } catch (IOException e) {
+                new SuppressingCloser(e).push(git);
+                throw new IllegalStateException("Wasn't able to open repository '%s': '%s".formatted(directory, e.getMessage()),
+                        e);
+            }
+        }
+
+        private void pull(Git git, FetchingService.Branches branches) {
+            try {
                 Log.infof("Pulling changes for sources branch of '%s':'%s'.", directory, branches.sources());
                 // just to make sure we are in the correct branch:
                 git.checkout().setName(branches.sources()).call();
@@ -112,8 +142,7 @@ public class GitCloneDirectory implements Closeable {
                                 "Fetching into '" + directory + "' (" + branches.sources() + "): "))
                         .setRefSpecs(branches.asRefArray())
                         .call();
-                return new GitCloneDirectory(git, this);
-            } catch (RuntimeException | GitAPIException | IOException e) {
+            } catch (RuntimeException | GitAPIException e) {
                 new SuppressingCloser(e).push(git);
                 throw new IllegalStateException(
                         "Wasn't able to pull changes for branch '%s' in repository '%s': '%s".formatted(branches,

--- a/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
+++ b/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
@@ -2,39 +2,71 @@ package io.quarkus.search.app.util;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.quarkus.search.app.fetching.FetchingService;
+import io.quarkus.search.app.fetching.LoggerProgressMonitor;
+
+import io.quarkus.logging.Log;
 
 import org.hibernate.search.util.common.impl.Closer;
+import org.hibernate.search.util.common.impl.SuppressingCloser;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.jboss.logging.Logger;
 
 public class GitCloneDirectory implements Closeable {
+
+    private static final Logger log = Logger.getLogger(GitCloneDirectory.class);
     private final Git git;
 
-    private final CloseableDirectory directory;
-    private final String pagesBranch;
+    private final GitDirectoryDetails directory;
     private RevTree pagesTree;
 
-    public GitCloneDirectory(Git git, CloseableDirectory directory, String pagesBranch) {
+    public GitCloneDirectory(Git git, GitDirectoryDetails directory) {
         this.git = git;
         this.directory = directory;
-        this.pagesBranch = pagesBranch;
+    }
+
+    public GitCloneDirectory(Git git, Path path, String pages) {
+        this(git, new GitDirectoryDetails(path, pages));
     }
 
     public Git git() {
         return git;
     }
 
-    public CloseableDirectory directory() {
+    public Path resolve(String other) {
+        return directory.directory().resolve(other);
+    }
+
+    public GitDirectoryDetails directory() {
         return directory;
+    }
+
+    public Path resolve(Path other) {
+        return directory.directory().resolve(other);
     }
 
     public RevTree pagesTree() {
         if (this.pagesTree == null) {
             try {
-                this.pagesTree = GitUtils.firstExistingRevTree(git().getRepository(), "origin/" + pagesBranch);
-            } catch (IOException e) {
-                throw new RuntimeException("Unable to locate pages branch: " + pagesBranch, e);
+                String remote;
+                List<RemoteConfig> remotes = git.remoteList().call();
+                if (remotes.isEmpty()) {
+                    remote = "";
+                } else {
+                    remote = remotes.get(0).getName() + "/";
+                }
+
+                this.pagesTree = GitUtils.firstExistingRevTree(git.getRepository(), remote + directory.pagesBranch());
+            } catch (GitAPIException | IOException e) {
+                throw new RuntimeException("Unable to locate pages branch: " + directory.pagesBranch(), e);
             }
         }
         return pagesTree;
@@ -44,8 +76,74 @@ public class GitCloneDirectory implements Closeable {
     public void close() throws IOException {
         try (Closer<IOException> closer = new Closer<>()) {
             closer.push(Git::close, git);
-            closer.push(CloseableDirectory::close, directory);
+            pagesTree = null;
         }
     }
 
+    @Override
+    public String toString() {
+        return "GitCloneDirectory{" +
+                "git=" + git +
+                ", directory=" + directory +
+                '}';
+    }
+
+    public record GitDirectoryDetails(Path directory, String pagesBranch) {
+        public GitCloneDirectory open() throws IOException {
+            return new GitCloneDirectory(Git.open(directory.toFile()), this);
+        }
+
+        public GitCloneDirectory pull(FetchingService.Branches branches) {
+            Log.infof("Pulling changes for '%s'.", directory);
+            Git git = null;
+            try {
+                git = Git.open(directory.toFile());
+                Log.infof("Pulling changes for sources branch of '%s':'%s'.", directory, branches.sources());
+                // just to make sure we are in the correct branch:
+                git.checkout().setName(branches.sources()).call();
+                // pull sources branch
+                git.pull()
+                        .setProgressMonitor(LoggerProgressMonitor.create(log,
+                                "Pulling into '" + directory + "' (" + branches.sources() + "): "))
+                        .call();
+                // fetch used branches
+                git.fetch().setForceUpdate(true)
+                        .setProgressMonitor(LoggerProgressMonitor.create(log,
+                                "Fetching into '" + directory + "' (" + branches.sources() + "): "))
+                        .setRefSpecs(branches.asRefArray())
+                        .call();
+                return new GitCloneDirectory(git, this);
+            } catch (RuntimeException | GitAPIException | IOException e) {
+                new SuppressingCloser(e).push(git);
+                throw new IllegalStateException(
+                        "Wasn't able to pull changes for branch '%s' in repository '%s': '%s".formatted(branches,
+                                directory,
+                                e.getMessage()),
+                        e);
+            }
+        }
+
+        public GitCloneDirectory clone(URI gitUri, FetchingService.Branches branches) {
+            Log.infof("Cloning into '%s' from '%s'.", directory, gitUri);
+            Git git = null;
+            try {
+                git = Git.cloneRepository()
+                        .setURI(gitUri.toString())
+                        .setDirectory(directory.toFile())
+                        .setDepth(1)
+                        .setNoTags()
+                        .setBranch(branches.sources())
+                        .setBranchesToClone(branches.asRefList())
+                        .setProgressMonitor(LoggerProgressMonitor.create(log, "Cloning " + gitUri + ": "))
+                        // Unfortunately sparse checkouts are not supported: https://www.eclipse.org/forums/index.php/t/1094825/
+                        .call();
+                return new GitCloneDirectory(git, this);
+            } catch (RuntimeException | GitAPIException e) {
+                new SuppressingCloser(e).push(git);
+                throw new IllegalStateException(
+                        "Failed to clone git repository into '%s' from '%s': %s".formatted(directory, gitUri, e.getMessage()),
+                        e);
+            }
+        }
+    }
 }

--- a/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
+++ b/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
@@ -147,6 +147,13 @@ public class GitCloneDirectory implements Closeable {
                 Log.infof("Pulling changes for sources branch of '%s':'%s'.", directory, branches.sources());
                 // just to make sure we are in the correct branch:
                 git.checkout().setName(branches.sources()).call();
+
+                if (git.getRepository().getRemoteNames().isEmpty()) {
+                    // Well... then there's nowhere to pull from,
+                    //  and we exit faster as pulling or fetching will fail in this scenario.
+                    return;
+                }
+
                 // pull sources branch
                 git.pull()
                         .setProgressMonitor(LoggerProgressMonitor.create(log,

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -171,15 +171,15 @@ class FetchingServiceTest {
     @RegisterExtension
     static final QuarkusComponentTestExtension extension = QuarkusComponentTestExtension.builder()
             .configProperty("fetching.timeout", "PT30s")
-            // NOTE: a more correct way to define these URIs would've been `dir.path().toUri().toString()`
-            //  so that schema and everything is added to a string and it is a correct URL.
-            //  We do not do it like that to trick the app into thinking that it is supplied with a non-local repository
-            //  and that it needs to clone it.
-            .configProperty("quarkusio.git-uri", tmpDir.path().toString())
-            .configProperty("quarkusio.localized.es.git-uri", localizedDirectories.get(Language.SPANISH).path().toString())
-            .configProperty("quarkusio.localized.pt.git-uri", localizedDirectories.get(Language.PORTUGUESE).path().toString())
-            .configProperty("quarkusio.localized.cn.git-uri", localizedDirectories.get(Language.CHINESE).path().toString())
-            .configProperty("quarkusio.localized.ja.git-uri", localizedDirectories.get(Language.JAPANESE).path().toString())
+            .configProperty("quarkusio.git-uri", tmpDir.path().toUri().toString())
+            .configProperty("quarkusio.localized.es.git-uri",
+                    localizedDirectories.get(Language.SPANISH).path().toUri().toString())
+            .configProperty("quarkusio.localized.pt.git-uri",
+                    localizedDirectories.get(Language.PORTUGUESE).path().toUri().toString())
+            .configProperty("quarkusio.localized.cn.git-uri",
+                    localizedDirectories.get(Language.CHINESE).path().toUri().toString())
+            .configProperty("quarkusio.localized.ja.git-uri",
+                    localizedDirectories.get(Language.JAPANESE).path().toUri().toString())
             .build();
 
     @Inject

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -62,7 +62,7 @@ class FetchingServiceTest {
         Path guide1HtmlToFetch = sourceRepoPath.resolve("guides/" + FETCHED_GUIDE_1_NAME + ".html");
         Path guide2HtmlToFetch = sourceRepoPath.resolve("version/2.7/guides/" + FETCHED_GUIDE_2_NAME + ".html");
         try (Git git = Git.init().setDirectory(sourceRepoPath.toFile())
-                .setInitialBranch(QuarkusIO.PAGES_BRANCH).call()) {
+                .setInitialBranch(QuarkusIO.MAIN_BRANCHES.pages()).call()) {
             GitTestUtils.cleanGitUserConfig();
 
             RevCommit initialCommit = git.commit().setMessage("Initial commit")
@@ -81,7 +81,7 @@ class FetchingServiceTest {
             git.commit().setMessage("Pages second commit").call();
 
             git.checkout()
-                    .setName(QuarkusIO.SOURCE_BRANCH)
+                    .setName(QuarkusIO.MAIN_BRANCHES.sources())
                     .setCreateBranch(true)
                     .setStartPoint(initialCommit)
                     .call();
@@ -105,7 +105,7 @@ class FetchingServiceTest {
             Path localizedGuide2HtmlToFetch = localizedSourceRepoPath
                     .resolve("docs/version/2.7/guides/" + FETCHED_GUIDE_2_NAME + ".html");
             try (Git git = Git.init().setDirectory(localizedSourceRepoPath.toFile())
-                    .setInitialBranch(QuarkusIO.LOCALIZED_PAGES_BRANCH).call()) {
+                    .setInitialBranch(QuarkusIO.LOCALIZED_BRANCHES.pages()).call()) {
                 GitTestUtils.cleanGitUserConfig();
 
                 RevCommit initialCommit = git.commit().setMessage("Initial commit")
@@ -124,7 +124,7 @@ class FetchingServiceTest {
                 git.commit().setMessage("Pages second commit").call();
 
                 git.checkout()
-                        .setName(QuarkusIO.LOCALIZED_SOURCE_BRANCH)
+                        .setName(QuarkusIO.LOCALIZED_BRANCHES.sources())
                         .setCreateBranch(true)
                         .setStartPoint(initialCommit)
                         .call();
@@ -147,12 +147,12 @@ class FetchingServiceTest {
         try (Git git = Git.open(sourceRepoPath.toFile())) {
             GitTestUtils.cleanGitUserConfig();
 
-            git.checkout().setName(QuarkusIO.PAGES_BRANCH).call();
+            git.checkout().setName(QuarkusIO.MAIN_BRANCHES.pages()).call();
             Files.writeString(guide1HtmlToFetch, FETCHED_GUIDE_1_CONTENT_HTML_UPDATED);
             git.add().addFilepattern(".").call();
             git.commit().setMessage("Pages updated commit").call();
 
-            git.checkout().setName(QuarkusIO.SOURCE_BRANCH).call();
+            git.checkout().setName(QuarkusIO.MAIN_BRANCHES.sources()).call();
 
             Files.writeString(metadata1ToFetch, METADATA_YAML_UPDATED);
             git.add().addFilepattern(".").call();


### PR DESCRIPTION
fixes https://github.com/quarkusio/search.quarkus.io/issues/85
fixes #126

Now `QuarkusIo` will only close the quarkiverse guides directory; repositories are going to be closed on the fetching bean been destroyed.

If we are pointing to a local dir repository then the fetching part is quick as there's nothing to pull/fetch and only zip files do not have an actual remote that can be called, so that one has a "special treatment" 😃 