### PR TITLE
Switch to a single-node cluster

### DIFF
--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -20,7 +20,6 @@ import io.quarkus.search.app.util.SimpleExecutor;
 
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.QuarkusTransaction;
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.scheduler.Scheduled;
 import io.quarkus.vertx.http.ManagementInterface;
@@ -141,10 +140,8 @@ public class IndexingService {
 
     private boolean isSearchBackendReady() {
         try {
-            String requiredStatus = LaunchMode.NORMAL.equals(LaunchMode.current()) ? "green" : "yellow";
             searchMapping.backend().unwrap(ElasticsearchBackend.class).client(RestClient.class)
-                    .performRequest(new Request("GET", "/_cluster/health?wait_for_status=%s&timeout=0s"
-                            .formatted(requiredStatus)));
+                    .performRequest(new Request("GET", "/_cluster/health?wait_for_status=green&timeout=0s"));
             return true;
         } catch (IOException e) {
             Log.debug("Caught exception when testing whether the search backend is reachable", e);

--- a/src/main/kubernetes/openshift.yml
+++ b/src/main/kubernetes/openshift.yml
@@ -145,7 +145,7 @@ metadata:
 # See https://www.hafifbilgiler.com/hafif-bilgiler/elasticsearch-installation-on-openshift/
 spec:
   serviceName: search-backend
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: search-backend
@@ -204,12 +204,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            # https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/#sample-docker-composeyml
-            # Rely on OpenShift's internal DNS to address the other hosts
-            - name: discovery.seed_hosts
-              value: "search-backend-0.search-backend,search-backend-1.search-backend,search-backend-2.search-backend"
-            - name: cluster.initial_cluster_manager_nodes
-              value: "search-backend-0,search-backend-1,search-backend-2"
+            # We don't have enough nodes/memory available in the cluster to allow for 3 decently-sized pods,
+            # and 3 pods with low memory perform badly, so we'll have to make do with a single pod.
+            - name: discovery.type
+              value: "single-node"
             # Memory locking doesn't work on our OpenShift instance,
             # but this shouldn't be too bad as we don't expect swapping to be enabled.
             - name: bootstrap.memory_lock

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -133,7 +133,7 @@ quarkus.container-image.builder=openshift
 quarkus.openshift.part-of=search-quarkus-io
 # See src/main/kubernetes/openshift.yml for the search-backend StatefulSet definition
 # Rely on OpenShift's internal DNS to resolve the IP to search-backend nodes
-quarkus.openshift.env.vars.quarkus-hibernate-search-orm-elasticsearch-hosts=search-backend-0.search-backend:9200,search-backend-1.search-backend:9200,search-backend-2.search-backend:9200
+quarkus.openshift.env.vars.quarkus-hibernate-search-orm-elasticsearch-hosts=search-backend-0.search-backend:9200
 # Images built on OpenShift have their HOME environment variable set to '/' by default,
 # which obviously won't work well due to filesystem permissions.
 # JGit in particular doesn't like it: https://bugs.eclipse.org/bugs/show_bug.cgi?id=560555


### PR DESCRIPTION
We don't have enough nodes/memory available in the cluster to allow for 3 decently-sized pods
and 3 pods with low memory perform badly, so we'll have to make do with a single node.