### PR TITLE
Allow Quarkus Core repo PR previews in CORS

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,7 +38,7 @@ indexing.batch-size=10
 
 # More secure HTTP defaults
 quarkus.http.cors=true
-quarkus.http.cors.origins=https://quarkus.io,/https://.*\\\\.quarkus\\\\.io/,/https://quarkus-(web)?site-pr-[0-9]+-preview\\\\.surge\\\\.sh/
+quarkus.http.cors.origins=https://quarkus.io,/https://.*\\\\.quarkus\\\\.io/,/https://quarkus-(.+-)?pr-.*-preview\\\\.surge\\\\.sh/
 quarkus.http.cors.methods=GET
 quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.http.header."X-Frame-Options".value=deny

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -165,7 +165,8 @@ class SearchServiceTest {
             "https://ja.quarkus.io",
             "https://pt.quarkus.io",
             "https://quarkus-site-pr-1825-preview.surge.sh",
-            "https://quarkus-website-pr-1825-preview.surge.sh"
+            "https://quarkus-website-pr-1825-preview.surge.sh",
+            "https://quarkus-pr-main-38430-preview.surge.sh"
     })
     void cors_allowed(String origin) {
         given()


### PR DESCRIPTION
So that things like https://quarkus-pr-main-38430-preview.surge.sh don't fail to run search anymore.