### PR TITLE
Fewer warnings on translations (Use rev trees for reading sources and HTMLs)

### DIFF
--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -58,8 +58,10 @@ public class FetchingService {
             }
             executor.waitForSuccessOrThrow(fetchingConfig.timeout());
             // If we get here, all tasks succeeded.
-            return new QuarkusIO(quarkusIOConfig, main.join(),
-                    localized.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().join())),
+            GitCloneDirectory mainRepository = main.join();
+            return new QuarkusIO(quarkusIOConfig, mainRepository,
+                    localized.entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().join().root(mainRepository))),
                     failureCollector);
         } catch (RuntimeException | IOException e) {
             new SuppressingCloser(e)

--- a/src/main/java/io/quarkus/search/app/indexing/FailureCollector.java
+++ b/src/main/java/io/quarkus/search/app/indexing/FailureCollector.java
@@ -69,7 +69,7 @@ public class FailureCollector implements Closeable {
     private final Consumer<EnumMap<Level, List<Failure>>> reporter;
 
     public FailureCollector() {
-        this.reporter = FailureCollector::logReporter;
+        this(IndexingConfig.GitErrorReporting.Type.LOG, Optional.empty());
     }
 
     public FailureCollector(IndexingConfig.GitErrorReporting config) {
@@ -113,7 +113,8 @@ public class FailureCollector implements Closeable {
     }
 
     private static void logReporter(EnumMap<Level, List<Failure>> failures) {
-        if (failures.isEmpty()) {
+        // failures are an enum map that we preinitialize, hence we check if there's anything in the lists:
+        if (failures.isEmpty() || failures.values().stream().allMatch(List::isEmpty)) {
             return;
         }
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -6,8 +6,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -15,7 +16,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -30,10 +30,14 @@ import io.quarkus.search.app.indexing.FailureCollector;
 import io.quarkus.search.app.util.CloseableDirectory;
 import io.quarkus.search.app.util.GitCloneDirectory;
 import io.quarkus.search.app.util.GitInputProvider;
+import io.quarkus.search.app.util.GitUtils;
 import io.quarkus.search.app.util.UrlInputProvider;
 
 import org.hibernate.search.util.common.impl.Closer;
 
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevTree;
 import org.fedorahosted.tennera.jgettext.Catalog;
 import org.fedorahosted.tennera.jgettext.Message;
 import org.fedorahosted.tennera.jgettext.PoParser;
@@ -60,12 +64,9 @@ public class QuarkusIO implements AutoCloseable {
         }
     }
 
-    public static String htmlPath(String version, String name) {
-        return httpPath(version, name) + ".html";
-    }
-
-    public static String localizedHtmlPath(String path) {
-        return "docs" + path + ".html";
+    public static String htmlPath(Language language, String version, String name) {
+        String htmlPath = httpPath(version, name) + ".html";
+        return (Language.ENGLISH.equals(language) ? "" : "docs" + (htmlPath.startsWith("/") ? "" : "/")) + htmlPath;
     }
 
     private static String httpPath(String version, String name) {
@@ -81,95 +82,228 @@ public class QuarkusIO implements AutoCloseable {
         return Path.of("_data", "versioned", version.replace('.', '-'), "index", "quarkiverse.yaml");
     }
 
-    private final URI webUri;
-    private final GitCloneDirectory mainRepository;
-    private final Map<Language, GitCloneDirectory> localizedSites;
-    private final Map<Language, URI> localizedSiteUris;
+    private final Map<Language, GitCloneDirectory> allSites;
+    private final Map<Language, URI> siteUris;
     private final CloseableDirectory prefetchedGuides = CloseableDirectory.temp("quarkiverse-guides-");
     private final FailureCollector failureCollector;
 
     public QuarkusIO(QuarkusIOConfig config, GitCloneDirectory mainRepository,
             Map<Language, GitCloneDirectory> localizedSites, FailureCollector failureCollector) throws IOException {
-        this.webUri = config.webUri();
-        this.mainRepository = mainRepository;
-        this.localizedSites = Collections.unmodifiableMap(localizedSites);
-        this.localizedSiteUris = localizedSites.entrySet().stream().collect(
-                Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> config.localized().get(e.getKey().code).webUri()));
+        HashMap<Language, URI> languageUriMap = new HashMap<>(localizedSites.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> config.localized().get(e.getKey().code).webUri())));
+        languageUriMap.put(Language.ENGLISH, config.webUri());
+        this.siteUris = Collections.unmodifiableMap(languageUriMap);
         this.failureCollector = failureCollector;
+
+        Map<Language, GitCloneDirectory> all = new HashMap<>(localizedSites);
+        all.put(Language.ENGLISH, mainRepository);
+        this.allSites = Collections.unmodifiableMap(all);
+
+        validateRepositories(mainRepository, localizedSites, failureCollector);
+    }
+
+    private static void validateRepositories(
+            GitCloneDirectory mainRepository,
+            Map<Language, GitCloneDirectory> localizedSites,
+            FailureCollector failureCollector) {
+        ObjectId latestMainRev = mainRepository.currentSourcesLatestHash();
+        for (Map.Entry<Language, GitCloneDirectory> localized : localizedSites.entrySet()) {
+            localized.getValue().currentUpstreamSubmoduleSourcesHash().ifPresentOrElse(commitHash -> {
+                if (latestMainRev.equals(commitHash)) {
+                    // means that the localized repo points to the latest main one and we can ignore further checks
+                    return;
+                }
+
+                // Otherwise let's see when the localized site was last synced,
+                // by looking at when that latest commit was committed:
+                Instant lastSync = GitUtils.committedInstant(mainRepository.git(), commitHash);
+                // Sync happens each week, so we can have
+                //  1. a commit to main repo on Monday
+                //  2. no further commits during the week
+                //  3. sync on the weekend (Sunday?)
+                //  4. commits to main repo
+                //  at this point the difference between latest commit in localized site and current date can be
+                //  more than 7 days; so we give it 2 weeks period before we start considering that there's a sync problem:
+                Duration duration = Duration.between(lastSync, Instant.now());
+                if (duration.compareTo(Duration.ofDays(14)) > 0) {
+                    failureCollector.warning(
+                            FailureCollector.Stage.TRANSLATION,
+                            "Localized repository '" + localized.getKey() + "' is out of sync for " + duration);
+                }
+            }, () -> {
+                failureCollector.warning(
+                        FailureCollector.Stage.PARSING,
+                        "Repository for a localized site '" + localized.getKey()
+                                + "' does not have an \"upstream\" directory. Site will be considered up-to-date. ");
+            });
+        }
     }
 
     @Override
     public void close() throws Exception {
         try (var closer = new Closer<Exception>()) {
             closer.push(CloseableDirectory::close, prefetchedGuides);
-            closer.push(GitCloneDirectory::close, mainRepository);
-            closer.pushAll(GitCloneDirectory::close, localizedSites.values());
+            closer.pushAll(GitCloneDirectory::close, allSites.values());
         }
     }
 
     public Stream<Guide> guides() throws IOException {
-        return Stream.concat(versionedGuides(), legacyGuides());
+        return Stream.concat(
+                Stream.concat(versionedGuides(), legacyGuides()),
+                Stream.concat(quarkiverseGuides(), legacyQuarkiverseGuides()));
     }
 
     // guides based on the info from the _data/versioned/[version]/index/
-    // may contain quarkus.yaml as well as quarkiverse.yml
-    private Stream<Guide> versionedGuides() throws IOException {
-        return Files.list(mainRepository.resolve("_data").resolve("versioned"))
-                .flatMap(p -> {
-                    var quarkusVersion = p.getFileName().toString().replace('-', '.');
-                    Path quarkiverse = p.resolve("index").resolve("quarkiverse.yaml");
-                    Path quarkus = p.resolve("index").resolve("quarkus.yaml");
-                    Map<Language, Catalog> translations = translations(
-                            (directory, language) -> resolveTranslationPath(p.getFileName().toString(),
-                                    quarkus.getFileName().toString(), directory, language));
+    private Stream<Guide> versionedGuides() {
+        return allSites.entrySet().stream()
+                .flatMap(entry -> {
+                    Language language = entry.getKey();
+                    GitCloneDirectory cloneDirectory = entry.getValue();
+                    RevTree translationSourcesTree = cloneDirectory.sourcesTranslationTree();
+                    Repository repository = cloneDirectory.git().getRepository();
 
-                    Stream<Guide> quarkusGuides = parseYamlMetadata(webUri, quarkus, quarkusVersion)
-                            .flatMap(guide -> translateGuide(guide, translations));
-                    if (Files.exists(quarkiverse)) {
-                        // the full content won't be translated, but the title/summary may be,
-                        // so we want to get that info out if available
-                        Map<Language, Catalog> quarkiverseTranslations = translations(
-                                (directory, language) -> resolveTranslationPath(p.getFileName().toString(),
-                                        quarkiverse.getFileName().toString(), directory, language));
-                        return Stream.concat(
-                                quarkusGuides,
-                                parseYamlQuarkiverseMetadata(quarkiverse, quarkusVersion)
-                                        .flatMap(guide -> translateGuide(guide, quarkiverseTranslations)));
-                    } else {
-                        return quarkusGuides;
+                    return cloneDirectory.sourcesFileStream("_data/versioned", path -> path.endsWith("quarkus.yaml"))
+                            .map(QuarkusIO::extractVersion)
+                            .flatMap(quarkusVersion -> {
+                                String quarkus = quarkusVersion.path();
+
+                                Catalog translations = translations(
+                                        repository, translationSourcesTree,
+                                        resolveTranslationPath(
+                                                quarkusVersion.versionDirectory(), "quarkus.yaml", language));
+
+                                try (InputStream file = cloneDirectory.sourcesFile(quarkus)) {
+                                    return parseYamlMetadata(cloneDirectory, file, quarkusVersion.version(), language,
+                                            translations);
+                                } catch (IOException e) {
+                                    throw new IllegalStateException(
+                                            "Unable to load %s: %s".formatted(quarkusVersion.path(), e.getMessage()),
+                                            e);
+                                }
+                            });
+                });
+    }
+
+    // older version guides like guides-2-7.yaml or guides-2-13.yaml
+    private Stream<Guide> legacyGuides() {
+        return allSites.entrySet().stream()
+                .flatMap(entry -> {
+                    Language language = entry.getKey();
+                    GitCloneDirectory cloneDirectory = entry.getValue();
+                    RevTree translationSourcesTree = cloneDirectory.sourcesTranslationTree();
+                    Repository repository = cloneDirectory.git().getRepository();
+
+                    return cloneDirectory.sourcesFileStream("_data", path -> path.matches("_data/guides-\\d+-\\d+\\.yaml"))
+                            .map(QuarkusIO::extractLegacyVersion)
+                            .flatMap(quarkusVersion -> {
+                                String quarkus = quarkusVersion.path();
+
+                                Catalog translations = translations(
+                                        repository, translationSourcesTree,
+                                        resolveLegacyTranslationPath(quarkusVersion.versionDirectory(), language));
+
+                                try (InputStream file = cloneDirectory.sourcesFile(quarkus)) {
+                                    return parseYamlLegacyMetadata(entry.getValue(), file, quarkusVersion.version(), language,
+                                            translations);
+                                } catch (IOException e) {
+                                    throw new IllegalStateException(
+                                            "Unable to load %s: %s".formatted(quarkusVersion.path(), e.getMessage()),
+                                            e);
+                                }
+                            });
+                });
+    }
+
+    private Stream<Guide> quarkiverseGuides() {
+        Language language = Language.ENGLISH;
+        GitCloneDirectory cloneDirectory = allSites.get(language);
+
+        return cloneDirectory.sourcesFileStream("_data/versioned", path -> path.endsWith("quarkiverse.yaml"))
+                .map(QuarkusIO::extractQuarkiverseVersion)
+                .flatMap(quarkusVersion -> {
+                    String quarkus = quarkusVersion.path();
+
+                    Map<Language, Catalog> translations = createTranslations(
+                            lang -> resolveTranslationPath(quarkusVersion.versionDirectory(), "quarkiverse.yaml", lang));
+
+                    try (InputStream file = cloneDirectory.sourcesFile(quarkus)) {
+                        return parseYamlQuarkiverseMetadata(file, quarkusVersion.version(), translations);
+                    } catch (IOException e) {
+                        throw new IllegalStateException(
+                                "Unable to load %s: %s".formatted(quarkusVersion.path(), e.getMessage()),
+                                e);
                     }
                 });
     }
 
-    private static Path resolveTranslationPath(String version, String filename, GitCloneDirectory directory,
-            Language language) {
-        return directory.resolve(
-                Path.of("l10n", "po", language.locale, "_data", "versioned", version, "index", filename + ".po"));
-    }
+    private Stream<Guide> legacyQuarkiverseGuides() {
+        Language language = Language.ENGLISH;
+        GitCloneDirectory cloneDirectory = allSites.get(language);
 
-    // older version guides like guides-2-7.yaml or guides-2-13.yaml
-    private Stream<Guide> legacyGuides() throws IOException {
-        return Files.list(mainRepository.resolve("_data"))
-                .filter(p -> !Files.isDirectory(p) && p.getFileName().toString().startsWith("guides-"))
-                .flatMap(p -> {
-                    var version = p.getFileName().toString().replaceAll("guides-|\\.yaml", "").replace('-', '.');
+        return cloneDirectory.sourcesFileStream("_data", path -> path.matches("_data/guides-\\d+-\\d+\\.yaml"))
+                .map(QuarkusIO::extractLegacyVersion)
+                .flatMap(quarkusVersion -> {
+                    String quarkus = quarkusVersion.path();
 
-                    Map<Language, Catalog> translations = translations(
-                            (directory, language) -> resolveLegacyTranslationPath(p.getFileName().toString(), directory,
-                                    language));
+                    Map<Language, Catalog> translations = createTranslations(
+                            lang -> resolveLegacyTranslationPath(quarkusVersion.versionDirectory(), lang));
 
-                    return parseYamlLegacyMetadata(webUri, p, version)
-                            .flatMap(guide -> translateGuide(guide, translations));
+                    try (InputStream file = cloneDirectory.sourcesFile(quarkus)) {
+                        return parseQuarkiverseYamlLegacyMetadata(cloneDirectory, file, quarkusVersion.version(), translations);
+                    } catch (IOException e) {
+                        throw new IllegalStateException(
+                                "Unable to load %s: %s".formatted(quarkusVersion.path(), e.getMessage()),
+                                e);
+                    }
                 });
     }
 
-    private static Path resolveLegacyTranslationPath(String filename, GitCloneDirectory directory, Language language) {
-        return directory.resolve(
-                Path.of("l10n", "po", language.locale, "_data", filename + ".po"));
+    private Map<Language, Catalog> createTranslations(Function<Language, String> pathCreator) {
+        Map<Language, Catalog> translations = new HashMap<>();
+        for (Map.Entry<Language, GitCloneDirectory> entry : allSites.entrySet()) {
+            Language lang = entry.getKey();
+            translations.put(lang, translations(
+                    entry.getValue().git().getRepository(), entry.getValue().sourcesTranslationTree(),
+                    pathCreator.apply(lang)));
+        }
+        return translations;
+    }
+
+    private static VersionAndPaths extractVersion(String relativePath) {
+        return extractVersion(relativePath, "quarkus.yaml");
+    }
+
+    private static VersionAndPaths extractQuarkiverseVersion(String relativePath) {
+        return extractVersion(relativePath, "quarkiverse.yaml");
+    }
+
+    private static VersionAndPaths extractVersion(String relativePath, String filename) {
+        String versionDirectory = relativePath.replace("_data/versioned/", "")
+                .replace("/index/", "").replace(filename, "");
+        return new VersionAndPaths(versionDirectory.replace('-', '.'), versionDirectory, relativePath);
+    }
+
+    private static VersionAndPaths extractLegacyVersion(String relativePath) {
+        return new VersionAndPaths(
+                relativePath.replace("_data/guides-", "")
+                        .replace(".yaml", "")
+                        .replace('-', '.'),
+                relativePath.replace("_data/", ""),
+                relativePath);
+    }
+
+    private static String resolveTranslationPath(String version, String filename, Language language) {
+        return Path.of("l10n", "po", language.locale, "_data", "versioned", version, "index", filename + ".po").toString();
+    }
+
+    private static String resolveLegacyTranslationPath(String filename, Language language) {
+        return Path.of("l10n", "po", language.locale, "_data", filename + ".po").toString();
     }
 
     @SuppressWarnings("unchecked")
-    private Stream<Guide> parseYamlMetadata(URI webUri, Path quarkusYamlPath, String quarkusVersion) {
+    private Stream<Guide> parseYamlMetadata(GitCloneDirectory cloneDirectory, InputStream quarkusYamlPath,
+            String quarkusVersion,
+            Language language, Catalog messages) {
         return parse(quarkusYamlPath, quarkusYaml -> {
             Set<Guide> parsed = new HashSet<>();
             for (Map<String, Object> parsedGuide : ((Map<String, List<Object>>) quarkusYaml.get("types")).entrySet()
@@ -177,11 +311,15 @@ public class QuarkusIO implements AutoCloseable {
                     .flatMap(e -> e.getValue().stream())
                     .map(e -> (Map<String, Object>) e).toList()) {
 
-                Guide guide = createGuide(webUri, quarkusVersion, toString(parsedGuide.get("type")), parsedGuide, "summary");
+                Guide guide = createGuide(cloneDirectory, quarkusVersion, toString(parsedGuide.get("type")), parsedGuide,
+                        "summary", language, messages);
+                if (guide == null) {
+                    continue;
+                }
                 guide.categories = toSet(parsedGuide.get("categories"));
-                guide.keywords.set(Language.ENGLISH, toString(parsedGuide.get("keywords")));
+                guide.keywords.set(language, translate(messages, toString(parsedGuide.get("keywords"))));
                 guide.topics = toSet(parsedGuide.get("topics")).stream()
-                        .map(v -> new I18nData<>(Language.ENGLISH, v))
+                        .map(v -> new I18nData<>(language, v))
                         .collect(Collectors.toList());
                 guide.extensions = toSet(parsedGuide.get("extensions"));
 
@@ -193,7 +331,8 @@ public class QuarkusIO implements AutoCloseable {
     }
 
     @SuppressWarnings("unchecked")
-    private Stream<Guide> parseYamlQuarkiverseMetadata(Path quarkusYamlPath, String quarkusVersion) {
+    private Stream<Guide> parseYamlQuarkiverseMetadata(InputStream quarkusYamlPath, String quarkusVersion,
+            Map<Language, Catalog> translations) {
         return parse(quarkusYamlPath, quarkusYaml -> {
             Set<Guide> parsed = new HashSet<>();
             for (Map.Entry<String, List<Map<String, Object>>> type : ((Map<String, List<Map<String, Object>>>) quarkusYaml
@@ -201,6 +340,13 @@ public class QuarkusIO implements AutoCloseable {
                 for (Map<String, Object> parsedGuide : type.getValue()) {
                     Guide guide = createQuarkiverseGuide(quarkusVersion, type.getKey(), parsedGuide, "summary");
                     guide.categories = toSet(parsedGuide.get("categories"));
+
+                    // Quarkiverse guides have a single URL, because content is not translated,
+                    // so there is a single Guide instance with translated maps for some of its metadata.
+                    translateAllForSameGuide(guide.title, translations);
+                    translateAllForSameGuide(guide.summary, translations);
+                    translateAllForSameGuide(guide.keywords, translations);
+
                     parsed.add(guide);
                 }
             }
@@ -209,18 +355,55 @@ public class QuarkusIO implements AutoCloseable {
         });
     }
 
+    private Stream<Guide> parseQuarkiverseYamlLegacyMetadata(GitCloneDirectory cloneDirectory, InputStream quarkusYamlPath,
+            String version,
+            Map<Language, Catalog> translations) {
+        return parseYamlLegacyMetadata(
+                cloneDirectory, quarkusYamlPath, version, Language.ENGLISH, translations.get(Language.ENGLISH),
+                (guide, guides) -> {
+                    if (guide.language == null) {
+                        translateAllForSameGuide(guide.title, translations);
+                        translateAllForSameGuide(guide.summary, translations);
+                        translateAllForSameGuide(guide.keywords, translations);
+                        guide.topics.forEach(topics -> translateAllForSameGuide(topics, translations));
+                        return guides.put(guide.url, guide);
+                    }
+                    return guide;
+                });
+    }
+
+    private Stream<Guide> parseYamlLegacyMetadata(GitCloneDirectory cloneDirectory, InputStream quarkusYamlPath, String version,
+            Language language, Catalog translations) {
+        return parseYamlLegacyMetadata(
+                cloneDirectory, quarkusYamlPath, version, language, translations, (guide, guides) -> {
+                    if (guide.language == null) {
+                        // this would mean that we want to create a quarkiverse guide, that should have all the languages,
+                        // we'll ignore it here, and address collecting quarkiverse guides from legacy metadata files in other place.
+                        return guide;
+                    }
+                    return guides.put(guide.url, guide);
+                });
+    }
+
     @SuppressWarnings("unchecked")
-    private Stream<Guide> parseYamlLegacyMetadata(URI webUri, Path quarkusYamlPath, String version) {
+    private Stream<Guide> parseYamlLegacyMetadata(GitCloneDirectory cloneDirectory, InputStream quarkusYamlPath,
+            String version, Language language, Catalog translations, BiFunction<Guide, Map<URI, Guide>, Guide> action) {
         return parse(quarkusYamlPath, quarkusYaml -> {
             Map<URI, Guide> parsed = new HashMap<>();
             for (Map<String, Object> categoryObj : ((List<Map<String, Object>>) quarkusYaml.get("categories"))) {
                 String category = toString(categoryObj.get("cat-id"));
                 for (Map<String, Object> parsedGuide : ((List<Map<String, Object>>) categoryObj.get("guides"))) {
-                    Guide guide = createGuide(webUri, version, "guide", parsedGuide, "description");
+                    Guide guide = createGuide(cloneDirectory, version, "guide", parsedGuide, "description", language,
+                            translations);
+                    if (guide == null) {
+                        continue;
+                    }
                     // since we can have the same link to a quarkiverse guide in multiple versions of quarkus,
                     // we want to somehow make them different in their ID:
                     guide.categories = Set.of(category);
-                    Guide old = parsed.put(guide.url, guide);
+
+                    Guide old = action.apply(guide, parsed);
+
                     if (old != null) {
                         guide.categories = combine(guide.categories, old.categories);
                     }
@@ -231,74 +414,22 @@ public class QuarkusIO implements AutoCloseable {
         });
     }
 
-    private Map<Language, Catalog> translations(BiFunction<GitCloneDirectory, Language, Path> translationPathResolver) {
-        Map<Language, Catalog> map = new HashMap<>();
-        for (Map.Entry<Language, GitCloneDirectory> entry : localizedSites.entrySet()) {
-            Language language = entry.getKey();
-            GitCloneDirectory directory = entry.getValue();
-            Path path = translationPathResolver.apply(directory, language);
-            Catalog messages;
-            try {
-                messages = new PoParser().parseCatalog(path.toFile());
-            } catch (IOException e) {
-                // it may be that not all localized sites are up-to-date, in that case we just assume that the translation is not there
-                // and the non-translated english text will be used.
-                failureCollector.warning(FailureCollector.Stage.TRANSLATION,
-                        "Unable to parse a translation file " + path + " : " + e.getMessage(), e);
-
-                messages = new Catalog();
-            }
-            map.put(language, messages);
+    private Catalog translations(Repository repository, RevTree sources, String path) {
+        if (sources == null) {
+            // for eng site:
+            return new Catalog();
         }
-        return map;
-    }
 
-    private Stream<Guide> translateGuide(Guide guide, Map<Language, Catalog> translations) {
-        if (guide.language == null) {
-            // Quarkiverse guides have a single URL, because content is not translated,
-            // so there is a single Guide instance with translated maps for some of its metadata.
-            translateAllForSameGuide(guide.title, translations);
-            translateAllForSameGuide(guide.summary, translations);
-            translateAllForSameGuide(guide.keywords, translations);
-            guide.topics.forEach(topics -> translateAllForSameGuide(topics, translations));
-            return Stream.of(guide);
+        try (InputStream file = GitUtils.file(repository, sources, path)) {
+            return new PoParser().parseCatalog(file, false);
+        } catch (IOException e) {
+            // it may be that not all localized sites are up-to-date, in that case we just assume that the translation is not there
+            // and the non-translated english text will be used.
+            failureCollector.warning(FailureCollector.Stage.TRANSLATION,
+                    "Unable to parse a translation file " + path + " : " + e.getMessage(), e);
+
+            return new Catalog();
         }
-        return Stream.concat(
-                Stream.of(guide),
-                localizedSites.entrySet().stream().map(entry -> {
-                    Language language = entry.getKey();
-                    GitCloneDirectory repository = entry.getValue();
-                    Catalog messages = translations.get(language);
-
-                    Guide translated = new Guide();
-                    translated.url = localizedUrl(language, guide);
-                    translated.language = language;
-                    translated.type = guide.type;
-                    translated.quarkusVersion = guide.quarkusVersion;
-                    translated.origin = guide.origin;
-                    translated.title = translateOneForNewGuide(guide.title, language, messages);
-                    translated.summary = translateOneForNewGuide(guide.summary, language, messages);
-                    GitInputProvider gitInputProvider = new GitInputProvider(
-                            repository.git(), repository.pagesTree(),
-                            localizedHtmlPath(guide.url.getPath()));
-                    if (!gitInputProvider.isFileAvailable()) {
-                        // if  a file is not present we do not want to add such guide. Since if the html is not there
-                        // it means that users won't be able to open it on the site, and returning it in the search results make it pointless.
-                        failureCollector.warning(FailureCollector.Stage.TRANSLATION,
-                                "Guide " + translated
-                                        + " is ignored since we were not able to find an HTML content file for it.");
-                        return null;
-                    }
-                    translated.htmlFullContentProvider.set(language, gitInputProvider);
-                    translated.categories = guide.categories;
-                    translated.extensions = guide.extensions;
-                    translated.keywords = translateOneForNewGuide(guide.keywords, language, messages);
-                    translated.topics = guide.topics.stream()
-                            .map(v -> translateOneForNewGuide(v, language, messages))
-                            .collect(Collectors.toList());
-
-                    return translated;
-                }).filter(Objects::nonNull));
     }
 
     private static void translateAllForSameGuide(I18nData<String> data, Map<Language, Catalog> translations) {
@@ -310,18 +441,6 @@ public class QuarkusIO implements AutoCloseable {
         for (Map.Entry<Language, Catalog> entry : translations.entrySet()) {
             data.set(entry.getKey(), translate(entry.getValue(), key));
         }
-    }
-
-    private static I18nData<String> translateOneForNewGuide(I18nData<String> oldData,
-            Language language, Catalog translations) {
-        String key = oldData.get(Language.ENGLISH);
-        I18nData<String> translatedData = new I18nData<>();
-        if (key == null) {
-            // No translation
-            return translatedData;
-        }
-        translatedData.set(language, translate(translations, key));
-        return translatedData;
     }
 
     private static String translate(Catalog messages, String key) {
@@ -337,19 +456,11 @@ public class QuarkusIO implements AutoCloseable {
                 : message.getMsgstr() == null || message.getMsgstr().isBlank() ? key : message.getMsgstr();
     }
 
-    private URI localizedUrl(Language language, Guide guide) {
-        URI url = guide.url;
-        try {
-            URI localized = localizedSiteUris.get(language);
-            return new URI(
-                    localized.getScheme(), localized.getAuthority(), url.getPath(),
-                    url.getQuery(), url.getFragment());
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(
-                    "Cannot create a localized version of the URL (%s). It is expected to have a correctly formatted URL at this point to a Quarkiverse guide (i.e. http://smth.smth/smth) : %s"
-                            .formatted(url, e.getMessage()),
-                    e);
+    private static void putIfNotNull(Map<Language, String> map, Language language, String value) {
+        if (value == null) {
+            return;
         }
+        map.put(language, value);
     }
 
     private static Set<String> combine(Set<String> a, Set<String> b) {
@@ -364,47 +475,58 @@ public class QuarkusIO implements AutoCloseable {
         return result;
     }
 
-    private static Stream<Guide> parse(Path quarkusYamlPath,
+    private static Stream<Guide> parse(InputStream inputStream,
             Function<Map<String, Object>, Stream<Guide>> parser) {
         Map<String, Object> quarkusYaml;
-        try (InputStream inputStream = Files.newInputStream(quarkusYamlPath)) {
-            Yaml yaml = new Yaml();
-            quarkusYaml = yaml.load(inputStream);
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to load %s: %s".formatted(quarkusYamlPath, e.getMessage()), e);
-        }
+        Yaml yaml = new Yaml();
+        quarkusYaml = yaml.load(inputStream);
 
         return parser.apply(quarkusYaml);
     }
 
-    private Guide createGuide(URI urlBase, String quarkusVersion, String type, Map<String, Object> parsedGuide,
-            String summaryKey) {
+    private Guide createGuide(GitCloneDirectory cloneDirectory, String quarkusVersion, String type,
+            Map<String, Object> parsedGuide,
+            String summaryKey, Language language, Catalog messages) {
         String parsedUrl = toString(parsedGuide.get("url"));
         if (parsedUrl.startsWith("http")) {
             // we are looking at a quarkiverse guide:
             return createQuarkiverseGuide(quarkusVersion, type, parsedGuide, summaryKey);
         } else {
-            return createCoreGuide(urlBase, quarkusVersion, type, parsedGuide, summaryKey);
+            return createCoreGuide(cloneDirectory, quarkusVersion, type, parsedGuide, summaryKey, language, messages);
         }
     }
 
-    private Guide createCoreGuide(URI urlBase, String quarkusVersion, String type, Map<String, Object> parsedGuide,
-            String summaryKey) {
+    private Guide createCoreGuide(GitCloneDirectory cloneDirectory, String quarkusVersion, String type,
+            Map<String, Object> parsedGuide,
+            String summaryKey, Language language, Catalog messages) {
         Guide guide = new Guide();
         guide.quarkusVersion = quarkusVersion;
-        guide.language = Language.ENGLISH;
+        guide.language = language;
         guide.origin = toString(parsedGuide.get("origin"));
         if (guide.origin == null) {
             guide.origin = QUARKUS_ORIGIN;
         }
         guide.type = type;
-        guide.title.set(Language.ENGLISH, renderMarkdown(toString(parsedGuide.get("title"))));
-        guide.summary.set(Language.ENGLISH, renderMarkdown(toString(parsedGuide.get(summaryKey))));
+        guide.title.set(language, renderMarkdown(translate(messages, toString(parsedGuide.get("title")))));
+        guide.summary.set(language, renderMarkdown(translate(messages, toString(parsedGuide.get(summaryKey)))));
         String parsedUrl = toString(parsedGuide.get("url"));
-        guide.url = httpUrl(urlBase, quarkusVersion, parsedUrl);
-        guide.htmlFullContentProvider.set(Language.ENGLISH,
-                new GitInputProvider(mainRepository.git(), mainRepository.pagesTree(),
-                        htmlPath(quarkusVersion, parsedUrl)));
+        guide.url = httpUrl(siteUris.get(language), quarkusVersion, parsedUrl);
+        GitInputProvider gitInputProvider = new GitInputProvider(cloneDirectory.git(), cloneDirectory.pagesTree(),
+                htmlPath(language, quarkusVersion, parsedUrl));
+        guide.htmlFullContentProvider.set(language, gitInputProvider);
+
+        if (!gitInputProvider.isFileAvailable()) {
+            // if  a file is not present we do not want to add such guide. Since if the html is not there
+            // it means that users won't be able to open it on the site, and returning it in the search results make it pointless.
+
+            // Since this file was listed in the yaml of a rev from which the site was built the html should've been present,
+            // but is missing for some reason that needs investigation:
+            failureCollector.warning(
+                    FailureCollector.Stage.TRANSLATION,
+                    "Guide " + guide + " is ignored since we were not able to find an HTML content file for it.");
+            return null;
+        }
+
         return guide;
     }
 
@@ -454,6 +576,9 @@ public class QuarkusIO implements AutoCloseable {
         return Arrays.stream(value.split(","))
                 .map(String::trim)
                 .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    record VersionAndPaths(String version, String versionDirectory, String path) {
     }
 
 }

--- a/src/main/java/io/quarkus/search/app/util/GitInputProvider.java
+++ b/src/main/java/io/quarkus/search/app/util/GitInputProvider.java
@@ -5,8 +5,6 @@ import java.io.InputStream;
 
 import io.quarkus.search.app.hibernate.InputProvider;
 
-import io.quarkus.logging.Log;
-
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.revwalk.RevTree;
 
@@ -27,12 +25,7 @@ public class GitInputProvider implements InputProvider {
     }
 
     public boolean isFileAvailable() {
-        try {
-            return GitUtils.fileExists(git.getRepository(), tree, path);
-        } catch (IOException e) {
-            Log.warn("A problem occurred while trying to find a file in git tree: " + e.getMessage(), e);
-            return false;
-        }
+        return GitUtils.fileExists(git.getRepository(), tree, path);
     }
 
     @Override

--- a/src/main/java/io/quarkus/search/app/util/GitUtils.java
+++ b/src/main/java/io/quarkus/search/app/util/GitUtils.java
@@ -2,8 +2,20 @@ package io.quarkus.search.app.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
+import io.quarkus.logging.Log;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.Repository;
@@ -11,6 +23,7 @@ import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.util.RawParseUtils;
 
 public final class GitUtils {
 
@@ -29,27 +42,74 @@ public final class GitUtils {
             throw new IllegalStateException("None of the refs '%s' exist in '%s'"
                     .formatted(Arrays.toString(originalRefs), repo));
         }
-        return new RevWalk(repo).parseTree(original);
+        return revTree(repo, original);
     }
 
-    public static InputStream file(Repository repo, RevTree tree, String path) throws IOException {
-        TreeWalk treeWalk = new TreeWalk(repo);
-        treeWalk.addTree(tree);
-        treeWalk.setRecursive(true);
-        treeWalk.setFilter(PathFilter.create(path));
-        if (!treeWalk.next()) {
-            throw new IllegalStateException("Missing file '%s' in '%s'".formatted(path, tree));
+    public static RevTree revTree(Repository repo, ObjectId rev) {
+        try {
+            return new RevWalk(repo).parseTree(rev);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        ObjectId objectId = treeWalk.getObjectId(0);
-        ObjectLoader loader = repo.open(objectId);
-        return loader.openStream();
     }
 
-    public static boolean fileExists(Repository repo, RevTree tree, String path) throws IOException {
-        TreeWalk treeWalk = new TreeWalk(repo);
-        treeWalk.addTree(tree);
-        treeWalk.setRecursive(true);
-        treeWalk.setFilter(PathFilter.create(path));
-        return treeWalk.next();
+    public static InputStream file(Repository repo, RevTree tree, String path) {
+        try {
+            TreeWalk treeWalk = new TreeWalk(repo);
+            treeWalk.addTree(tree);
+            treeWalk.setRecursive(true);
+            treeWalk.setFilter(PathFilter.create(path));
+            if (!treeWalk.next()) {
+                throw new IllegalStateException("Missing file '%s' in '%s'".formatted(path, tree));
+            }
+            ObjectId objectId = treeWalk.getObjectId(0);
+            ObjectLoader loader = repo.open(objectId);
+            return loader.openStream();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean fileExists(Repository repo, RevTree tree, String path) {
+        try {
+            TreeWalk treeWalk = new TreeWalk(repo);
+            treeWalk.addTree(tree);
+            treeWalk.setRecursive(true);
+            treeWalk.setFilter(PathFilter.create(path));
+            return treeWalk.next();
+        } catch (IOException e) {
+            Log.warn("A problem occurred while trying to find a file in git tree: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    public static Stream<String> fileStream(Repository repo, RevTree tree, String path, Predicate<String> filenameFilter) {
+        try {
+            List<String> files = new ArrayList<>();
+
+            TreeWalk treeWalk = new TreeWalk(repo);
+            treeWalk.addTree(tree);
+            treeWalk.setRecursive(true);
+            treeWalk.setFilter(PathFilter.create(path));
+
+            while (treeWalk.next()) {
+                byte[] rawPath = treeWalk.getRawPath();
+                String fullName = RawParseUtils.decode(StandardCharsets.UTF_8, rawPath, 0, rawPath.length);
+                if (filenameFilter.test(fullName)) {
+                    files.add(fullName);
+                }
+            }
+            return files.stream();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Instant committedInstant(Git git, ObjectId revId) {
+        try {
+            return Instant.ofEpochSecond(git.log().add(revId).call().iterator().next().getCommitTime());
+        } catch (GitAPIException | MissingObjectException | IncorrectObjectTypeException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/io/quarkus/search/app/testsupport/QuarkusIOSample.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/QuarkusIOSample.java
@@ -390,8 +390,8 @@ public final class QuarkusIOSample {
             c.addLocalizedMetadata(language, SAMPLED_NON_LATEST_VERSION);
             c.addLocalizedQuarkiverseMetadata(language, SAMPLED_NON_LATEST_VERSION);
             for (GuideRef guideRef : GuideRef.local()) {
-                c.addLocalizedGuide(guideRef, QuarkusVersions.LATEST);
-                c.addLocalizedGuide(guideRef, SAMPLED_NON_LATEST_VERSION);
+                c.addLocalizedGuide(language, guideRef, QuarkusVersions.LATEST);
+                c.addLocalizedGuide(language, guideRef, SAMPLED_NON_LATEST_VERSION);
             }
         }
     }
@@ -409,7 +409,7 @@ public final class QuarkusIOSample {
         }
 
         public FilterDefinitionCollector addGuide(GuideRef ref, String version) {
-            String htmlPath = QuarkusIO.htmlPath(version, ref.name());
+            String htmlPath = QuarkusIO.htmlPath(Language.ENGLISH, version, ref.name());
             htmlPath = htmlPath.startsWith("/") ? htmlPath.substring(1) : htmlPath;
             addOnPagesBranch(htmlPath, htmlPath);
             return this;
@@ -429,9 +429,8 @@ public final class QuarkusIOSample {
             return this;
         }
 
-        public FilterDefinitionCollector addLocalizedGuide(GuideRef ref, String version) {
-            String htmlPath = QuarkusIO.htmlPath(version, ref.name());
-            htmlPath = "docs" + (htmlPath.startsWith("/") ? "" : "/") + htmlPath;
+        public FilterDefinitionCollector addLocalizedGuide(Language language, GuideRef ref, String version) {
+            String htmlPath = QuarkusIO.htmlPath(language, version, ref.name());
             addOnPagesBranch(htmlPath, htmlPath);
             return this;
         }


### PR DESCRIPTION
Opening as a draft so we have a place to discuss this 😃 

so the idea here is that we can check if the upstream in localized site is the same thing that main was generated from, and if it is -- we'd be expecting that all files should be in place (either translated, or original ones) and if some are missing then that's a problem. 
now as there was a problem once that es site didn't get synced for some time I thought it may be ok to log a warning in that case... that's that part about the `localizedSitesUpToDate` map.  if that makes sense, we could also extract the acceptable period to a configurable property.