### PR TITLE
Allow container reuse

### DIFF
--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -136,7 +136,7 @@ public class FetchingService {
     public void cleanupTemporaryFolders() {
         try (Closer<IOException> closer = new Closer<>()) {
             closer.pushAll(CloseableDirectory::close, tempDirectories);
-        } catch (Exception e) {
+        } catch (RuntimeException | IOException e) {
             throw new IllegalStateException(
                     "Failed to close directories '%s': %s".formatted(tempDirectories, e.getMessage()), e);
         }

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -122,7 +122,7 @@ public class IndexingService {
             Log.infof("Scheduled reindex finished.");
         } catch (ReindexingAlreadyInProgressException e) {
             Log.infof("Indexing was already started by some other process.");
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.errorf(e, "Failed to start scheduled reindex: %s", e.getMessage());
         }
     }
@@ -226,7 +226,7 @@ public class IndexingService {
 
             rollover.commit();
             Log.info("Indexing success");
-        } catch (Exception e) {
+        } catch (RuntimeException | IOException e) {
             throw new IllegalStateException("Failed to index data: " + e.getMessage(), e);
         }
     }
@@ -266,7 +266,7 @@ public class IndexingService {
                         try {
                             Log.tracef("About to persist: %s", doc);
                             session.persist(doc);
-                        } catch (Exception e) {
+                        } catch (RuntimeException e) {
                             throw new IllegalStateException("Failed to persist '%s': %s".formatted(doc, e.getMessage()), e);
                         }
                     }

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -119,13 +119,13 @@ public class IndexingService {
     @Scheduled(cron = "{indexing.scheduled.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void indexOnTime() {
         try {
-            Log.infof("Scheduled reindex starting...");
+            Log.infof("Scheduled reindexing starting...");
             reindex();
-            Log.infof("Scheduled reindex finished.");
+            Log.infof("Scheduled reindexing finished.");
         } catch (ReindexingAlreadyInProgressException e) {
             Log.infof("Indexing was already started by some other process.");
         } catch (RuntimeException e) {
-            Log.errorf(e, "Failed to start scheduled reindex: %s", e.getMessage());
+            Log.errorf(e, "Failed to start scheduled reindexing: %s", e.getMessage());
         }
     }
 

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -116,7 +116,7 @@ public class IndexingService {
                         t -> Log.errorf(t, "Reindexing on startup failed: %s", t.getMessage()));
     }
 
-    @Scheduled(cron = "{indexing.scheduled.cron}")
+    @Scheduled(cron = "{indexing.scheduled.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void indexOnTime() {
         try {
             Log.infof("Scheduled reindex starting...");

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -2,6 +2,7 @@ package io.quarkus.search.app.quarkusio;
 
 import static io.quarkus.search.app.util.MarkdownRenderer.renderMarkdown;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -43,7 +44,7 @@ import org.fedorahosted.tennera.jgettext.Message;
 import org.fedorahosted.tennera.jgettext.PoParser;
 import org.yaml.snakeyaml.Yaml;
 
-public class QuarkusIO implements AutoCloseable {
+public class QuarkusIO implements Closeable {
 
     public static final String QUARKUS_ORIGIN = "quarkus";
     private static final String QUARKIVERSE_ORIGIN = "quarkiverse";
@@ -140,8 +141,8 @@ public class QuarkusIO implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
-        try (var closer = new Closer<Exception>()) {
+    public void close() throws IOException {
+        try (var closer = new Closer<IOException>()) {
             closer.push(CloseableDirectory::close, prefetchedGuides);
             closer.pushAll(GitCloneDirectory::close, allSites.values());
         }

--- a/src/main/java/io/quarkus/search/app/util/MutinyUtils.java
+++ b/src/main/java/io/quarkus/search/app/util/MutinyUtils.java
@@ -16,7 +16,7 @@ public final class MutinyUtils {
         // https://smallrye.io/smallrye-mutiny/2.0.0/guides/polling/#how-to-use-polling
         return Multi.createBy().repeating()
                 .supplier(condition)
-                .until(backendReachable -> backendReachable)
+                .until(conditionMet -> conditionMet)
                 .onItem().invoke(onRetry)
                 // https://smallrye.io/smallrye-mutiny/2.5.1/guides/controlling-demand/#pacing-the-demand
                 .paceDemand().on(Infrastructure.getDefaultWorkerPool())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,10 +70,10 @@ quarkus.hibernate-search-orm.elasticsearch.indexing.max-bulk-size=20
 ## We need to apply a custom OpenSearch mapping to exclude very large fields from the _source
 quarkus.hibernate-search-orm.elasticsearch.schema-management.mapping-file=indexes/mapping-template.json
 quarkus.hibernate-search-orm.elasticsearch.schema-management.settings-file=indexes/settings-template.json
-## We don't expect OpenSearch to be reachable when the application starts
-quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false
+## In production, we don't expect OpenSearch to be reachable when the application starts
+%prod.quarkus.hibernate-search-orm.elasticsearch.version-check.enabled=false
 ## ... and the application automatically creates indexes upon first indexing anyway.
-quarkus.hibernate-search-orm.schema-management.strategy=none
+%prod.quarkus.hibernate-search-orm.schema-management.strategy=none
 ## Make sure there are always enough backend connections available.
 ## In particular, we need to have extra connections for search
 ## even when heavily indexing, otherwise liveness/readiness checks will fail

--- a/src/test/java/io/quarkus/search/app/indexing/RolloverTest.java
+++ b/src/test/java/io/quarkus/search/app/indexing/RolloverTest.java
@@ -26,6 +26,7 @@ import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -95,6 +96,12 @@ class RolloverTest {
 
     @BeforeEach
     void recreateIndexes() {
+        deleteAllIndexes();
+        searchMapping.scope(Object.class).schemaManager().createOrValidate();
+    }
+
+    @AfterEach
+    void deleteAllIndexes() {
         Set<String> aliasedIndexes = searchMapping.allIndexedEntities().stream()
                 .map(this::aliased)
                 .map(Rollover.GetAliasedResult::allAliasedIndexes)
@@ -107,7 +114,6 @@ class RolloverTest {
                 throw new IllegalStateException(e);
             }
         }
-        searchMapping.scope(Object.class).schemaManager().createOrValidate();
     }
 
     @Test

--- a/src/test/java/io/quarkus/search/app/indexing/SchedulerTest.java
+++ b/src/test/java/io/quarkus/search/app/indexing/SchedulerTest.java
@@ -42,14 +42,6 @@ class SchedulerTest {
     };
     private static final String GUIDES_SEARCH = "/guides/search";
 
-    protected int managementPort() {
-        if (getClass().getName().endsWith("IT")) {
-            return 9000;
-        } else {
-            return 9001;
-        }
-    }
-
     @Test
     void scheduler() {
         // since we've disabled the index-on-start there should be no indexes until the scheduler kicks in:

--- a/src/test/java/io/quarkus/search/app/testsupport/GitTestUtils.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/GitTestUtils.java
@@ -1,5 +1,8 @@
 package io.quarkus.search.app.testsupport;
 
+import java.io.IOException;
+
+import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.util.SystemReader;
@@ -15,7 +18,7 @@ public final class GitTestUtils {
     public static void cleanGitUserConfig() {
         try {
             clearRecursively(SystemReader.getInstance().getUserConfig());
-        } catch (Exception e) {
+        } catch (RuntimeException | ConfigInvalidException | IOException e) {
             LOG.warn("Unable to get Git user config");
         }
     }
@@ -27,7 +30,7 @@ public final class GitTestUtils {
         if (config instanceof StoredConfig storedConfig) {
             try {
                 storedConfig.clear();
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 LOG.warnf("Unable to clear Git config %s", config);
             }
         }


### PR DESCRIPTION
A few fixes that make the build pass even when we [reuse the OpenSearch container](https://quarkus.io/guides/elasticsearch-dev-services#reuse) between tests.