### PR TITLE
Less aggressive polling when waiting for indexing in tests

### DIFF
--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -5,7 +5,6 @@ import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -17,6 +16,7 @@ import io.quarkus.search.app.dto.GuideSearchHit;
 import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.testsupport.GuideRef;
 import io.quarkus.search.app.testsupport.QuarkusIOSample;
+import io.quarkus.search.app.testsupport.SetupUtil;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -31,7 +31,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
-import org.awaitility.Awaitility;
 
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -46,14 +45,6 @@ class SearchServiceTest {
     };
     private static final String GUIDES_SEARCH = "/guides/search";
 
-    protected int managementPort() {
-        if (getClass().getName().endsWith("IT")) {
-            return 9000;
-        } else {
-            return 9001;
-        }
-    }
-
     private SearchResult<GuideSearchHit> search(String term) {
         return given()
                 .queryParam("q", term)
@@ -64,12 +55,8 @@ class SearchServiceTest {
     }
 
     @BeforeAll
-    void waitForIndexing() {
-        Awaitility.await().timeout(Duration.ofMinutes(1)).untilAsserted(() -> {
-            when().get("http://localhost:" + managementPort() + "/q/health/ready")
-                    .then()
-                    .statusCode(200);
-        });
+    void setup() {
+        SetupUtil.waitForIndexing(getClass());
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails(LogDetail.BODY);
     }
 

--- a/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
@@ -4,13 +4,13 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
 import io.quarkus.search.app.dto.GuideSearchHit;
 import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.testsupport.QuarkusIOSample;
+import io.quarkus.search.app.testsupport.SetupUtil;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import org.awaitility.Awaitility;
 
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -36,20 +34,9 @@ class SynonymSearchServiceTest {
     };
     private static final String GUIDES_SEARCH = "guides/search";
 
-    protected int managementPort() {
-        if (getClass().getName().endsWith("IT")) {
-            return 9000;
-        } else {
-            return 9001;
-        }
-    }
-
     @BeforeAll
-    void waitForIndexing() {
-        Awaitility.await().timeout(Duration.ofMinutes(1))
-                .untilAsserted(() -> when().get("http://localhost:" + managementPort() + "/q/health/ready")
-                        .then()
-                        .statusCode(200));
+    void setup() {
+        SetupUtil.waitForIndexing(getClass());
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails(LogDetail.BODY);
     }
 

--- a/src/test/java/io/quarkus/search/app/indexing/SchedulerTest.java
+++ b/src/test/java/io/quarkus/search/app/indexing/SchedulerTest.java
@@ -1,15 +1,10 @@
 package io.quarkus.search.app.indexing;
 
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.Duration;
 import java.util.Map;
 
 import io.quarkus.search.app.SearchService;
-import io.quarkus.search.app.dto.GuideSearchHit;
-import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.testsupport.QuarkusIOSample;
+import io.quarkus.search.app.testsupport.SetupUtil;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -18,10 +13,6 @@ import io.quarkus.test.junit.TestProfile;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-
-import org.awaitility.Awaitility;
-
-import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
 @TestProfile(SchedulerTest.Profile.class)
@@ -38,21 +29,10 @@ class SchedulerTest {
         }
     }
 
-    private static final TypeRef<SearchResult<GuideSearchHit>> SEARCH_RESULT_SEARCH_HITS = new TypeRef<>() {
-    };
-    private static final String GUIDES_SEARCH = "/guides/search";
-
     @Test
     void scheduler() {
         // since we've disabled the index-on-start there should be no indexes until the scheduler kicks in:
-        Awaitility.await().timeout(Duration.ofMinutes(1)).pollDelay(Duration.ofSeconds(15)).untilAsserted(() -> {
-            assertThat(given()
-                    .when().get(GUIDES_SEARCH)
-                    .then()
-                    .statusCode(200)
-                    .extract().body().as(SEARCH_RESULT_SEARCH_HITS)
-                    .total().lowerBound()).isPositive();
-        });
+        SetupUtil.waitForIndexing(getClass());
     }
 
 }

--- a/src/test/java/io/quarkus/search/app/testsupport/SetupUtil.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/SetupUtil.java
@@ -1,0 +1,31 @@
+package io.quarkus.search.app.testsupport;
+
+import static io.restassured.RestAssured.when;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.awaitility.pollinterval.FibonacciPollInterval;
+
+public final class SetupUtil {
+    private SetupUtil() {
+    }
+
+    public static int managementPort(Class<?> testClass) {
+        if (testClass.getName().endsWith("IT")) {
+            return 9000;
+        } else {
+            return 9001;
+        }
+    }
+
+    public static void waitForIndexing(Class<?> testClass) {
+        Awaitility.await().timeout(Duration.ofMinutes(1))
+                .pollInterval(FibonacciPollInterval.fibonacci(1, TimeUnit.SECONDS))
+                .untilAsserted(() -> when().get("http://localhost:" + managementPort(testClass) + "/q/health/ready")
+                        .then()
+                        .statusCode(200));
+    }
+
+}


### PR DESCRIPTION
Otherwise we pollute logs with many healthcheck failures.