### PR TITLE
Adjust how translation missing exception is handled

### DIFF
--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -423,7 +423,7 @@ public class QuarkusIO implements Closeable {
 
         try (InputStream file = GitUtils.file(repository, sources, path)) {
             return new PoParser().parseCatalog(file, false);
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             // it may be that not all localized sites are up-to-date, in that case we just assume that the translation is not there
             // and the non-translated english text will be used.
             failureCollector.warning(FailureCollector.Stage.TRANSLATION,

--- a/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
+++ b/src/main/java/io/quarkus/search/app/util/GitCloneDirectory.java
@@ -151,7 +151,7 @@ public class GitCloneDirectory implements Closeable {
         }
     }
 
-    public InputStream sourcesFile(String filename) {
+    public InputStream sourcesFile(String filename) throws IOException {
         GitCloneDirectory cloneDirectory = root == null ? this : root;
         return GitUtils.file(cloneDirectory.git().getRepository(), sourcesTree(), filename);
     }

--- a/src/main/java/io/quarkus/search/app/util/GitUtils.java
+++ b/src/main/java/io/quarkus/search/app/util/GitUtils.java
@@ -53,21 +53,17 @@ public final class GitUtils {
         }
     }
 
-    public static InputStream file(Repository repo, RevTree tree, String path) {
-        try {
-            TreeWalk treeWalk = new TreeWalk(repo);
-            treeWalk.addTree(tree);
-            treeWalk.setRecursive(true);
-            treeWalk.setFilter(PathFilter.create(path));
-            if (!treeWalk.next()) {
-                throw new IllegalStateException("Missing file '%s' in '%s'".formatted(path, tree));
-            }
-            ObjectId objectId = treeWalk.getObjectId(0);
-            ObjectLoader loader = repo.open(objectId);
-            return loader.openStream();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    public static InputStream file(Repository repo, RevTree tree, String path) throws IOException {
+        TreeWalk treeWalk = new TreeWalk(repo);
+        treeWalk.addTree(tree);
+        treeWalk.setRecursive(true);
+        treeWalk.setFilter(PathFilter.create(path));
+        if (!treeWalk.next()) {
+            throw new IllegalStateException("Missing file '%s' in '%s'".formatted(path, tree));
         }
+        ObjectId objectId = treeWalk.getObjectId(0);
+        ObjectLoader loader = repo.open(objectId);
+        return loader.openStream();
     }
 
     public static boolean fileExists(Repository repo, RevTree tree, String path) {


### PR DESCRIPTION
See https://github.com/quarkusio/search.quarkus.io/issues/130#issuecomment-2040995960

So it was supposed to be a warning, it's just that the runtime exception from `gitutils#file` was never caught all the way up to the indexing... 