### PR TITLE
Properly define serialization of Language (for OpenAPI in particular)

### DIFF
--- a/src/main/java/io/quarkus/search/app/ReferenceService.java
+++ b/src/main/java/io/quarkus/search/app/ReferenceService.java
@@ -1,6 +1,5 @@
 package io.quarkus.search.app;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -54,8 +53,8 @@ public class ReferenceService {
     @Operation(summary = "List available languages")
     @Path("/languages")
     @CacheResult(cacheName = REFERENCE_CACHE, keyGenerator = MethodNameCacheKeyGenerator.class)
-    public List<String> languages() {
-        return Arrays.stream(Language.values()).map(lang -> lang.code).toList();
+    public Language[] languages() {
+        return Language.values();
     }
 
     @GET

--- a/src/main/java/io/quarkus/search/app/entity/Language.java
+++ b/src/main/java/io/quarkus/search/app/entity/Language.java
@@ -3,6 +3,8 @@ package io.quarkus.search.app.entity;
 import java.util.EnumSet;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum Language {
     ENGLISH("en", "en_US"),
     SPANISH("es", "es_ES"),
@@ -24,6 +26,11 @@ public enum Language {
 
     public String addSuffix(String prefix) {
         return prefix == null || prefix.isEmpty() ? null : "%s_%s".formatted(prefix, code);
+    }
+
+    @JsonValue // Must be on a method for Smallrye-OpenAPI to handle it -- fields won't work.
+    public String code() {
+        return code;
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Fixes an invalid schema generated by Smallrye-OpenAPI, where enums were represented by their name instead of their code:

![image](https://github.com/quarkusio/search.quarkus.io/assets/412878/60dfa68e-da95-4953-8c08-1aecf9106816)

Becomes:

![image](https://github.com/quarkusio/search.quarkus.io/assets/412878/6711c247-b9eb-4587-8e26-82418317309c)
