### PR TITLE
Use only form elements with the name attribute defined

### DIFF
--- a/src/main/resources/web/app/qs-form.ts
+++ b/src/main/resources/web/app/qs-form.ts
@@ -84,7 +84,7 @@ export class QsForm extends LitElement {
     }
 
     private _getFormElements(): NodeListOf<HTMLFormElement> {
-        return this.querySelectorAll('input, select');
+        return this.querySelectorAll('input[name], select[name]');
     }
 
     private _readQueryInputs() {


### PR DESCRIPTION
Without this, other form elements can trigger undesired search as mentioned here https://github.com/quarkusio/quarkusio.github.io/pull/1895#issuecomment-2042758187