### PR TITLE
Read query input parameters when the form is fully initialized

### DIFF
--- a/src/main/resources/web/app/qs-form.ts
+++ b/src/main/resources/web/app/qs-form.ts
@@ -73,7 +73,6 @@ export class QsForm extends LitElement {
           formElement.value = value;
         }
       }
-      this._handleInputChange(null);
     }
   }
 
@@ -104,6 +103,9 @@ export class QsForm extends LitElement {
       const eventName = this._isInput(el) ? 'input' : 'change';
       el.addEventListener(eventName, this._handleInputChange);
     });
+    // Read the initial form data.
+    // Should only be done once the form is fully initialized and all attributes are already set.
+    this._handleInputChange(null);
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
Attributes passed to the form, such as `quarkus-version` are not yet initialized in the constructor and if we read the form data in the constructor all of those attr values will not be in the initial search request (can happen when a link with a search query is shared/opened)