### PR TITLE
Use relative URLs for quarkus guides

### DIFF
--- a/src/main/resources/web/app/qs-guide.ts
+++ b/src/main/resources/web/app/qs-guide.ts
@@ -102,6 +102,7 @@ export class QsGuide extends LitElement {
   @property({type: String}) keywords: string;
   @property({type: String}) content: string | [string]
   @property({type: String}) origin: string = "quarkus";
+  @property({type: String, attribute: 'origins-with-relative-urls'}) originsWithRelativeUrls: string[] = [];
 
 
   connectedCallback() {
@@ -127,7 +128,7 @@ export class QsGuide extends LitElement {
         </div>
         <div>
           <h4>
-            <a href="${this.url}" target="${this.url.startsWith('http') ? '_blank' : ''}">${this._renderHTML(this.title)}</a>
+            <a href="${this.relativizeUrl()}" target="_blank">${this._renderHTML(this.title)}</a>
             ${(this.origin && this.origin.toLowerCase() !== 'quarkus') ? html`<span class="origin ${this.origin}" title="${this.origin}"></span>` : ''}
           </h4>
           <div class="summary">
@@ -140,6 +141,14 @@ export class QsGuide extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  private relativizeUrl(): string {
+    if (this.originsWithRelativeUrls.includes(this.origin)) {
+      return this.url.substring(new URL(this.url).origin.length);
+    } else {
+      return this.url;
+    }
   }
 
   private icon(): string {

--- a/src/main/resources/web/app/qs-target.ts
+++ b/src/main/resources/web/app/qs-target.ts
@@ -125,7 +125,7 @@ export class QsTarget extends LitElement {
     switch (this.type) {
       case 'guide':
         return html`
-          <qs-guide class="qs-hit" .data=${i}></qs-guide>`
+          <qs-guide class="qs-hit" .data=${i} origins-with-relative-urls="quarkus"></qs-guide>`
     }
     return ''
   }


### PR DESCRIPTION
fixes https://github.com/quarkusio/search.quarkus.io/issues/273

That's what I was thinking of ... 

By the way, the `_target` was always blank since we were returning all the URLs as absolute. With the change, Quarkus guides will open on the same page as the search, while Quarkiverse guides will open in a new tab. Do we want to keep opening Quakrus guides in the new tab?