### PR TITLE
Update to OpenSearch 2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <version.formatter.plugin>2.24.1</version.formatter.plugin>
     <version.impsort-maven-plugin>1.10.0</version.impsort-maven-plugin>
     <!-- This version needs to match the version in src/main/docker/opensearch-custom.Dockerfile -->
-    <version.opensearch>2.14</version.opensearch>
+    <version.opensearch>2.15</version.opensearch>
     <version.quarkus-web-bundler>1.6.0</version.quarkus-web-bundler>
   </properties>
   <dependencyManagement>

--- a/src/main/docker/opensearch-custom.Dockerfile
+++ b/src/main/docker/opensearch-custom.Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.14.0
+FROM opensearchproject/opensearch:2.15.0
 
 # Workaround for https://github.com/opensearch-project/opensearch-devops/issues/97
 RUN chmod -R go=u /usr/share/opensearch

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -65,7 +65,7 @@ quarkus.rest.path=/api
 # Hibernate Search
 ########################
 # This version needs to match the version in src/main/docker/opensearch-custom.Dockerfile
-quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.14
+quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.15
 # Not using :latest here as a workaround until we get https://github.com/quarkusio/quarkus/pull/38896
 quarkus.elasticsearch.devservices.image-name=opensearch-custom:${maven.version.opensearch}
 # Limit parallelism of indexing, because OpenSearch can only handle so many documents in its buffers.


### PR DESCRIPTION
The build for Hibernate Search passed https://github.com/hibernate/hibernate-search/pull/4211

So we can try it here as well 😃. (before dependabot opens a PR for it 😈😆)