### PR TITLE
Reduce indexing.parallelism in half

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,7 +38,7 @@ indexing.scheduled.cron=0 0 0 * * ?
 # of bulk requests to Elasticsearch, making it unlikely that an indexing queue
 # will be empty in the middle of indexing.
 # See quarkus.hibernate-search-standalone.elasticsearch.indexing below.
-indexing.parallelism=80
+indexing.parallelism=40
 indexing.batch-size=10
 # Error reporting to GitHub issue:
 # See https://github.com/quarkusio/search.quarkus.io/issues/89


### PR DESCRIPTION
I couldn't see this in any environment variables, so maybe we should just update it in the property file.