### PR TITLE
Send fewer indexing requests to OpenSearch in parallel on staging

### DIFF
--- a/src/main/helm/values.staging.yaml
+++ b/src/main/helm/values.staging.yaml
@@ -3,7 +3,7 @@ app:
     QUARKUS_PROFILE: 'staging'
     # Avoid overloading the rather resource-constrained OpenSearch instance
     INDEXING_BULK_SIZE: '10'
-    INDEXING_QUEUE_COUNT: '12'
+    INDEXING_QUEUE_COUNT: '6'
   resources:
     limits:
       cpu: 2000m


### PR DESCRIPTION
So that OpenSearch don't end up leaving requests hanging for more than 30s.

Fixes #290, hopefully.