### PR TITLE
Update GitHub issue title when indexing starts

### DIFF
--- a/src/main/java/io/quarkus/search/app/indexing/reporting/GithubStatusReporter.java
+++ b/src/main/java/io/quarkus/search/app/indexing/reporting/GithubStatusReporter.java
@@ -53,40 +53,48 @@ class GithubStatusReporter implements StatusReporter {
             toStatusDetailsMarkdown(newReportBuilder, failures, true);
             String newReport = newReportBuilder.toString();
 
-            // Update the issue description with the content of the latest comment,
-            // for convenience, and to have information available even when indexing is unstable (no issue comment).
-            // This must be done before the comment, so that notifications triggered by the comment are only sent
-            // when the issue is fully updated.
-            issue.setBody(StatusRenderer.insertMessageInIssueDescription(issue.getBody(), newReport));
+            if (status == Status.IN_PROGRESS) {
+                // Don't update the issue description before completion.
+            } else {
+                // On completion, update the issue description with the content of the latest comment,
+                // for convenience, and to have information available even when indexing is unstable (no issue comment).
+                // This must be done before the comment, so that notifications triggered by the comment are only sent
+                // when the issue is fully updated.
+                issue.setBody(StatusRenderer.insertMessageInIssueDescription(issue.getBody(), newReport));
+            }
 
             // add comments if needed:
-            if (!Status.SUCCESS.equals(status)) {
-                String reportComment = StatusRenderer.truncateForGitHubMaxLength(newReport, 0);
-                switch (status) {
-                    case WARNING -> {
-                        // When warning, only comment if we didn't comment the same thing recently.
-                        var lastRecentCommentByMe = getStatusCommentsSince(
-                                issue,
-                                clock.instant().minus(config.warningRepeatDelay()))
-                                .reduce(Streams.last());
-                        if (lastRecentCommentByMe.isPresent()
-                                && lastRecentCommentByMe.get().getBody().contentEquals(reportComment)) {
-                            Log.infof("Skipping the issue comment because the same message was sent recently.");
-                        } else {
-                            issue.comment(reportComment);
-                        }
-                    }
-                    case UNSTABLE -> {
-                        // When unstable, never comment: there'll be a retry, and we want to avoid unnecessary noise.
-                    }
-                    case CRITICAL ->
-                        // When critical, always comment.
-                        issue.comment(reportComment);
+            String reportComment = StatusRenderer.truncateForGitHubMaxLength(newReport, 0);
+            switch (status) {
+                case IN_PROGRESS, SUCCESS -> {
+                    // When in progress or successful, never comment: we want to avoid unnecessary noise.
                 }
+                case WARNING -> {
+                    // When warning, only comment if we didn't comment the same thing recently.
+                    var lastRecentCommentByMe = getStatusCommentsSince(
+                            issue,
+                            clock.instant().minus(config.warningRepeatDelay()))
+                            .reduce(Streams.last());
+                    if (lastRecentCommentByMe.isPresent()
+                            && lastRecentCommentByMe.get().getBody().contentEquals(reportComment)) {
+                        Log.infof("Skipping the issue comment because the same message was sent recently.");
+                    } else {
+                        issue.comment(reportComment);
+                    }
+                }
+                case UNSTABLE -> {
+                    // When unstable, never comment: there'll be a retry, and we want to avoid unnecessary noise.
+                }
+                case CRITICAL ->
+                    // When critical, always comment.
+                    issue.comment(reportComment);
             }
 
             // handle issue state (open/close):
             switch (status) {
+                case IN_PROGRESS -> {
+                    Log.infof("Leaving GitHub issue in its current open/close state pending completion.");
+                }
                 case SUCCESS, WARNING -> {
                     if (GHIssueState.OPEN.equals(issue.getState())) {
                         Log.infof("Closing GitHub issue as indexing succeeded.");

--- a/src/main/java/io/quarkus/search/app/indexing/reporting/LogStatusReporter.java
+++ b/src/main/java/io/quarkus/search/app/indexing/reporting/LogStatusReporter.java
@@ -20,7 +20,7 @@ public class LogStatusReporter implements StatusReporter {
     public void report(Status status, Map<FailureCollector.Level, List<Failure>> failures) {
         StringBuilder sb = new StringBuilder(StatusRenderer.toStatusSummary(clock, status, "Indexing status"));
         switch (status) {
-            case SUCCESS -> {
+            case IN_PROGRESS, SUCCESS -> {
                 Log.info(sb);
             }
             case WARNING, UNSTABLE -> {

--- a/src/main/java/io/quarkus/search/app/indexing/reporting/Status.java
+++ b/src/main/java/io/quarkus/search/app/indexing/reporting/Status.java
@@ -1,6 +1,7 @@
 package io.quarkus.search.app.indexing.reporting;
 
 public enum Status {
+    IN_PROGRESS,
     SUCCESS,
     WARNING,
     /**

--- a/src/main/java/io/quarkus/search/app/indexing/reporting/StatusRenderer.java
+++ b/src/main/java/io/quarkus/search/app/indexing/reporting/StatusRenderer.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public abstract class StatusRenderer {
     private static final String TITLE_UPDATED_AND_STATUS_FORMAT = ": %s (updated %s)";
     private static final Pattern TITLE_UPDATED_AND_STATUS_PATTERN = Pattern
-            .compile("(:\s*([^() ]+) )?\s*\\(updated [^)]+\\)");
+            .compile("(:\\s*([^(): ][^():]+) )?\\s*\\(updated [^)]+\\)");
     private static final DateTimeFormatter UPDATED_DATE_FORMAT = DateTimeFormatter.ofPattern(
             "uuuu-MM-dd'T'HH:mm:ssZZZZZ",
             Locale.ROOT);
@@ -40,6 +40,7 @@ public abstract class StatusRenderer {
 
     private static Object formatStatus(Status status) {
         return switch (status) {
+            case IN_PROGRESS -> "In progress";
             case SUCCESS -> "Success";
             case WARNING -> "Warning";
             case CRITICAL -> "Critical";
@@ -114,7 +115,7 @@ public abstract class StatusRenderer {
         }
         int currentIndex = startMarkerIndex + INSERT_START_MARKER.length();
 
-        String quoteIntroMessage = "\n## Last update\n";
+        String quoteIntroMessage = "\n## Latest indexing report\n";
         result.insert(currentIndex, quoteIntroMessage);
         currentIndex += quoteIntroMessage.length();
 

--- a/src/main/java/io/quarkus/search/app/indexing/state/IndexingState.java
+++ b/src/main/java/io/quarkus/search/app/indexing/state/IndexingState.java
@@ -50,6 +50,7 @@ public class IndexingState {
             scheduledRetry.cancel();
             scheduledRetry = null;
         }
+        reporter.report(Status.IN_PROGRESS, Map.of());
         return new Attempt(allowRetry);
     }
 

--- a/src/test/java/io/quarkus/search/app/indexing/reporting/StatusRendererTest.java
+++ b/src/test/java/io/quarkus/search/app/indexing/reporting/StatusRendererTest.java
@@ -45,6 +45,8 @@ class StatusRendererTest {
             WARNING,[PROD] search.quarkus.io indexing status: Success (updated 2024-05-28T00:03:23Z)
             [PROD] search.quarkus.io indexing status: Success (updated 1970-01-01T00:00:00Z),\
             SUCCESS,[PROD] search.quarkus.io indexing status: Success (updated 2024-05-28T00:03:23Z)
+            [PROD] search.quarkus.io indexing status: Success (updated 1970-01-01T00:00:00Z),\
+            SUCCESS,[PROD] search.quarkus.io indexing status: In progress (updated 2024-05-28T00:03:23Z)
             """)
     void toStatusSummary(String expected, Status status, String currentTitle) {
         assertThat(StatusRenderer.toStatusSummary(clock, status, currentTitle))
@@ -55,7 +57,7 @@ class StatusRendererTest {
     @CsvSource(textBlock = """
             'Original description
             <!-- Automatic message start -->
-            ## Last update
+            ## Latest indexing report
             > Automatic message
             > and some more
             <!-- Automatic message end -->',\
@@ -64,7 +66,7 @@ class StatusRendererTest {
             and some more'
             'Original description
             <!-- Automatic message start -->
-            ## Last update
+            ## Latest indexing report
             > New automatic message
             > and some more
             <!-- Automatic message end -->',\

--- a/src/test/java/io/quarkus/search/app/indexing/state/IndexingStateTest.java
+++ b/src/test/java/io/quarkus/search/app/indexing/state/IndexingStateTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.Function;
 
 import io.quarkus.search.app.indexing.reporting.FailureCollector.Stage;
@@ -42,6 +43,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             // No warning/critical: success
         }
@@ -57,6 +59,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             // Try concurrent indexing...
             assertThatThrownBy(() -> state.tryStart(true))
@@ -74,6 +77,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.warning(Stage.INDEXING, "Some warning");
         }
@@ -89,6 +93,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -104,6 +109,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(false)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -123,6 +129,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -135,6 +142,7 @@ public class IndexingStateTest {
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             verify(cancellableMock).cancel();
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -147,6 +155,7 @@ public class IndexingStateTest {
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             verify(cancellableMock).cancel();
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             // No warning/critical: success
         }
@@ -166,6 +175,7 @@ public class IndexingStateTest {
 
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -178,6 +188,7 @@ public class IndexingStateTest {
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             verify(cancellableMock).cancel();
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -190,6 +201,7 @@ public class IndexingStateTest {
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             verify(cancellableMock).cancel();
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
@@ -203,20 +215,20 @@ public class IndexingStateTest {
                 new ExplicitRetryConfig(3, Duration.ofMinutes(2)), retrySchedulerMock);
         assertThat(state.isInProgress()).isFalse();
 
-        var cancellableMock = mock(Cancellable.class);
-        when(retrySchedulerMock.apply(any())).thenReturn(cancellableMock);
-
         try (IndexingState.Attempt attempt = state.tryStart(true)) {
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }
         verify(statusReporterMock).report(eq(Status.UNSTABLE), anyMap());
         assertThat(state.isInProgress()).isFalse();
 
+        reset(statusReporterMock);
+
         try (IndexingState.Attempt attempt = state.tryStart(false)) {
-            verify(cancellableMock).cancel();
             assertThat(state.isInProgress()).isTrue();
+            verify(statusReporterMock).report(eq(Status.IN_PROGRESS), eq(Map.of()));
 
             attempt.critical(Stage.INDEXING, "Something critical");
         }


### PR DESCRIPTION
So that we see something like this when we look at the GitHub issue: 

![image](https://github.com/user-attachments/assets/a6fb6ad8-2bea-413b-93f0-48aa4df22557)
