### PR TITLE
Use fast-vector highlighting and force-merge after indexing

### DIFF
--- a/src/main/helm/values.staging.yaml
+++ b/src/main/helm/values.staging.yaml
@@ -2,8 +2,8 @@ app:
   envs:
     QUARKUS_PROFILE: 'staging'
     # Avoid overloading the rather resource-constrained OpenSearch instance
-    INDEXING_BULK_SIZE: '10'
     INDEXING_QUEUE_COUNT: '6'
+    INDEXING_BULK_SIZE: '10'
   resources:
     limits:
       cpu: 2000m

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -36,7 +36,7 @@ import io.vertx.ext.web.Router;
 @Path("/")
 public class SearchService {
 
-    private static final int NO_MATCH_SIZE = 32_600;
+    private static final int TITLE_OR_SUMMARY_MAX_SIZE = 32_600;
     private static final int PAGE_SIZE = 50;
     private static final long TOTAL_HIT_COUNT_THRESHOLD = 100;
     private static final String MAX_FOR_PERF_MESSAGE = "{jakarta.validation.constraints.Max.message} for performance reasons";
@@ -73,8 +73,8 @@ public class SearchService {
                             f.id(),
                             f.field("type"),
                             f.field("origin"),
-                            f.highlight(language.addSuffix("title")).single(),
-                            f.highlight(language.addSuffix("summary")).single(),
+                            f.highlight(language.addSuffix("title")).highlighter("highlighter_title_or_summary").single(),
+                            f.highlight(language.addSuffix("summary")).highlighter("highlighter_title_or_summary").single(),
                             f.highlight(language.addSuffix("fullContent")).highlighter("highlighter_content"))
                             .asList(GuideSearchHit::new))
                     .where((f, root) -> {
@@ -108,21 +108,25 @@ public class SearchService {
                                             .boost(50.0f)));
                         }
                     })
-                    // * Highlighters are going to use spans-with-classes so that we will have more control over styling the visual on the search results screen.
-                    // * We give control to the caller on the content snippet length and the number of these fragments
-                    // * No match size is there to make sure that we are still going to get the text even if the field didn't have a match in it.
-                    // * The title in the Guide entity is `Length.LONG` long, so we use that as a max value for no-match size, but hopefully nobody writes a title that long...
-                    .highlighter(
-                            f -> f.unified().noMatchSize(NO_MATCH_SIZE).fragmentSize(0)
-                                    .orderByScore(true)
-                                    .numberOfFragments(1)
-                                    .tag("<span class=\"" + highlightCssClass + "\">", "</span>")
-                                    .boundaryScanner().sentence().end())
-                    // * If there's no match in the full content we don't want to return anything.
-                    // * Also content is really huge, so we want to only get small parts of the sentences. We are allowing caller to pick the number of sentences and their length:
-                    .highlighter("highlighter_content",
-                            f -> f.unified().noMatchSize(0).numberOfFragments(contentSnippets)
-                                    .fragmentSize(contentSnippetsLength))
+                    .highlighter(f -> f.unified()
+                            // Highlighters are going to use spans-with-classes so that we will have more control over styling the visual on the search results screen.
+                            .tag("<span class=\"" + highlightCssClass + "\">", "</span>"))
+                    .highlighter("highlighter_title_or_summary", f -> f.unified()
+                            // We want the whole text of the field, regardless of whether it has a match or not.
+                            .noMatchSize(TITLE_OR_SUMMARY_MAX_SIZE)
+                            .fragmentSize(TITLE_OR_SUMMARY_MAX_SIZE)
+                            // We want the whole text as a single fragment
+                            .numberOfFragments(1))
+                    .highlighter("highlighter_content", f -> f.unified()
+                            // If there's no match in the full content we don't want to return anything.
+                            .noMatchSize(0)
+                            // Content is really huge, so we want to only get small parts of the sentences.
+                            // We give control to the caller on the content snippet length and the number of these fragments
+                            .numberOfFragments(contentSnippets)
+                            .fragmentSize(contentSnippetsLength)
+                            // The rest of fragment configuration is static
+                            .orderByScore(true)
+                            .boundaryScanner().sentence().end())
                     .sort(f -> f.score().then().field(language.addSuffix("title_sort")))
                     .routing(QuarkusVersionAndLanguageRoutingBinder.searchKeys(version, language))
                     .totalHitCountThreshold(TOTAL_HIT_COUNT_THRESHOLD + (page + 1) * PAGE_SIZE)

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -46,12 +46,12 @@ public class Guide {
     @KeywordField
     public String origin;
 
-    @I18nFullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
+    @I18nFullTextField(highlightable = Highlightable.FAST_VECTOR, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nFullTextField(name = "title_autocomplete", analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nKeywordField(name = "title_sort", normalizerPrefix = AnalysisConfigurer.SORT, searchable = Searchable.NO, sortable = Sortable.YES)
     public I18nData<String> title = new I18nData<>();
 
-    @I18nFullTextField(highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
+    @I18nFullTextField(highlightable = Highlightable.FAST_VECTOR, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nFullTextField(name = "summary_autocomplete", analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     public I18nData<String> summary = new I18nData<>();
 
@@ -59,7 +59,7 @@ public class Guide {
     @I18nFullTextField(name = "keywords_autocomplete", analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     public I18nData<String> keywords = new I18nData<>();
 
-    @I18nFullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.UNIFIED, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
+    @I18nFullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.FAST_VECTOR, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nFullTextField(name = "fullContent_autocomplete", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
     public I18nData<InputProvider> htmlFullContentProvider = new I18nData<>();

--- a/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
@@ -44,10 +44,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
         return language.addSuffix(AUTOCOMPLETE);
     }
 
-    private static String stopFilter(Language language) {
-        return "stop_%s".formatted(language.code);
-    }
-
     private static String regularStemmerFilter(Language language) {
         return "stemmer_%s".formatted(language.code);
     }
@@ -99,8 +95,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "lowercase",
                         // To remove possessives (trailing 's) from words.
                         possessiveStemmerFilter(language),
-                        // To remove frequently used words that do not bring much meaning, e.g. a, that, and, are, as, at, with...
-                        stopFilter(language),
                         // To remove suffixes like -s/-es/-ed etc
                         regularStemmerFilter(language),
                         // To convert characters into ascii ones, e.g. à to a or ę to e etc.
@@ -113,7 +107,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                 .tokenFilters(
                         "lowercase",
                         possessiveStemmerFilter(language),
-                        stopFilter(language),
                         regularStemmerFilter(language),
                         "asciifolding",
                         // > In general, synonym filters rewrite their inputs to the tokenizer and filters used in the preceding analysis chain
@@ -133,7 +126,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         compoundTechnicalNameFilter(language),
                         "lowercase",
                         possessiveStemmerFilter(language),
-                        stopFilter(language),
                         regularStemmerFilter(language),
                         "asciifolding",
                         autocompleteEdgeNgramFilter(language))
@@ -156,7 +148,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "kuromoji_part_of_speech",
                         possessiveStemmerFilter(language),
                         "ja_stop",
-                        stopFilter(language),
                         "kuromoji_stemmer",
                         regularStemmerFilter(language),
                         "asciifolding")
@@ -175,7 +166,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "kuromoji_part_of_speech",
                         possessiveStemmerFilter(language),
                         "ja_stop",
-                        stopFilter(language),
                         "kuromoji_stemmer",
                         regularStemmerFilter(language),
                         "asciifolding",
@@ -193,7 +183,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "kuromoji_part_of_speech",
                         possessiveStemmerFilter(language),
                         "ja_stop",
-                        stopFilter(language),
                         "kuromoji_stemmer",
                         regularStemmerFilter(language),
                         "asciifolding",
@@ -218,7 +207,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "lowercase",
                         possessiveStemmerFilter(language),
                         "smartcn_stop",
-                        stopFilter(language),
                         regularStemmerFilter(language),
                         "asciifolding")
                 .charFilters("html_strip");
@@ -229,7 +217,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                 .tokenFilters(
                         "lowercase",
                         possessiveStemmerFilter(language),
-                        stopFilter(language),
                         regularStemmerFilter(language),
                         "asciifolding",
                         synonymsGraphFilter(language),
@@ -244,7 +231,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "lowercase",
                         possessiveStemmerFilter(language),
                         "smartcn_stop",
-                        stopFilter(language),
                         regularStemmerFilter(language),
                         "asciifolding",
                         autocompleteEdgeNgramFilter(language))
@@ -256,10 +242,6 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
     }
 
     private static void configureSharedFilters(ElasticsearchAnalysisConfigurationContext context, Language language) {
-        context.tokenFilter(stopFilter(language))
-                .type("stop")
-                .param("stopwords", "_english_")
-                .param("ignore_case", "true");
         context.tokenFilter(regularStemmerFilter(language))
                 .type("stemmer")
                 .param("language", "english");

--- a/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
+++ b/src/main/java/io/quarkus/search/app/indexing/IndexingService.java
@@ -238,6 +238,8 @@ public class IndexingService {
                 var future = searchMapping.scope(Object.class).massIndexer()
                         // no point in cleaning the data because of the rollover ^
                         .purgeAllOnStart(false)
+                        // data is read-only after indexing -- we may as well have a single segment
+                        .mergeSegmentsOnFinish(true)
                         .batchSizeToLoadObjects(indexingConfig.batchSize())
                         .threadsToLoadObjects(indexingConfig.parallelism().orElse(6))
                         .context(QuarkusIOLoadingContext.class, QuarkusIOLoadingContext.of(quarkusIO))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,9 +72,9 @@ quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.16
 quarkus.elasticsearch.devservices.image-name=opensearch-custom:${maven.version.opensearch}
 quarkus.elasticsearch.devservices.java-opts=${PROD_OPENSEARCH_JAVA_OPTS}
 # Limit parallelism of indexing, because OpenSearch can only handle so many documents in its buffers.
-# This leads to at most 12*20=240 documents being indexed in parallel, which should be plenty
+# This leads to at most 8*20=160 documents being indexed in parallel, which should be plenty
 # given how large our documents can be.
-INDEXING_QUEUE_COUNT=12
+INDEXING_QUEUE_COUNT=8
 INDEXING_BULK_SIZE=20
 quarkus.hibernate-search-standalone.elasticsearch.indexing.queue-count=${INDEXING_QUEUE_COUNT}
 quarkus.hibernate-search-standalone.elasticsearch.indexing.max-bulk-size=${INDEXING_BULK_SIZE}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,6 +70,7 @@ quarkus.rest.path=/api
 quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.16
 # Not using :latest here as a workaround until we get https://github.com/quarkusio/quarkus/pull/38896
 quarkus.elasticsearch.devservices.image-name=opensearch-custom:${maven.version.opensearch}
+quarkus.elasticsearch.devservices.java-opts=${PROD_OPENSEARCH_JAVA_OPTS}
 # Limit parallelism of indexing, because OpenSearch can only handle so many documents in its buffers.
 # This leads to at most 12*20=240 documents being indexed in parallel, which should be plenty
 # given how large our documents can be.
@@ -236,7 +237,8 @@ quarkus.helm.values."opensearch-image".paths=(kind == StatefulSet).spec.template
 quarkus.helm.values."opensearch-image".value=opensearch-custom:${maven.revision}
 quarkus.helm.values."opensearch-image".property=@.opensearch.image
 # Resource requirements (overridden for staging, see src/main/helm)
-quarkus.helm.values."@.opensearch.envs.OPENSEARCH_JAVA_OPTS".value=\ -Xms1g -Xmx1g
+PROD_OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+quarkus.helm.values."@.opensearch.envs.OPENSEARCH_JAVA_OPTS".value=\ ${PROD_OPENSEARCH_JAVA_OPTS}
 quarkus.helm.values."@.opensearch.resources.limits.cpu".value=2000m
 quarkus.helm.values."@.opensearch.resources.requests.cpu".value=500m
 quarkus.helm.values."@.opensearch.resources.limits.memory".value=2Gi

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -366,7 +366,9 @@ class SearchServiceTest {
         assertThat(result.hits()).extracting(GuideSearchHit::content).hasSize(9)
                 .allSatisfy(content -> assertThat(content).hasSize(1)
                         .allSatisfy(hitsHaveCorrectWordHighlighted(matches, "orm", "highlighted-content")));
-        assertThat(matches.get()).isEqualTo(10);
+        assertThat(matches.get())
+                .as("Number of occurrences of 'orm' in " + result.hits().stream().map(GuideSearchHit::content).toList())
+                .isEqualTo(10);
     }
 
     @Test

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -203,8 +203,8 @@ class SearchServiceTest {
                         // TODO Shouldn't the ORM guide be before Panache?
                         GuideRef.HIBERNATE_ORM_PANACHE,
                         GuideRef.HIBERNATE_ORM,
-                        GuideRef.HIBERNATE_ORM_PANACHE_KOTLIN,
                         GuideRef.HIBERNATE_SEARCH_ORM_ELASTICSEARCH,
+                        GuideRef.HIBERNATE_ORM_PANACHE_KOTLIN,
                         GuideRef.HIBERNATE_REACTIVE_PANACHE,
                         GuideRef.HIBERNATE_REACTIVE)),
                 Arguments.of("reactive", GuideRef.urls(
@@ -217,8 +217,8 @@ class SearchServiceTest {
                         GuideRef.HIBERNATE_REACTIVE,
                         GuideRef.HIBERNATE_REACTIVE_PANACHE,
                         GuideRef.HIBERNATE_ORM_PANACHE,
-                        GuideRef.HIBERNATE_ORM_PANACHE_KOTLIN,
-                        GuideRef.HIBERNATE_ORM)),
+                        GuideRef.HIBERNATE_ORM,
+                        GuideRef.HIBERNATE_ORM_PANACHE_KOTLIN)),
                 Arguments.of("jpa", GuideRef.urls(
                         GuideRef.HIBERNATE_ORM,
                         GuideRef.HIBERNATE_ORM_PANACHE,
@@ -433,7 +433,7 @@ class SearchServiceTest {
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.hits()).extracting(GuideSearchHit::title)
                 .contains(
-                        "<span class=\"highlighted\">Duplicated</span> <span class=\"highlighted\">context</span>, <span class=\"highlighted\">context</span> <span class=\"highlighted\">locals</span>, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> and <span class=\"highlighted\">propagation</span>");
+                        "<span class=\"highlighted\">Duplicated</span> <span class=\"highlighted\">context</span>, <span class=\"highlighted\">context</span> <span class=\"highlighted\">locals</span>, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> <span class=\"highlighted\">and</span> <span class=\"highlighted\">propagation</span>");
     }
 
     @Test
@@ -447,7 +447,7 @@ class SearchServiceTest {
         assertThat(result.hits()).extracting(GuideSearchHit::title)
                 .contains(
                         // unified highlighter will still "highlight" the phrase word by word:
-                        "Duplicated context, context locals, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> and <span class=\"highlighted\">propagation</span>");
+                        "Duplicated context, context locals, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> <span class=\"highlighted\">and</span> <span class=\"highlighted\">propagation</span>");
     }
 
     @Test
@@ -514,7 +514,7 @@ class SearchServiceTest {
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.hits()).extracting(GuideSearchHit::title)
                 .contains(
-                        "<span class=\"highlighted\">Duplicated</span> <span class=\"highlighted\">context</span>, <span class=\"highlighted\">context</span> <span class=\"highlighted\">locals</span>, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> and <span class=\"highlighted\">propagation</span>");
+                        "<span class=\"highlighted\">Duplicated</span> <span class=\"highlighted\">context</span>, <span class=\"highlighted\">context</span> <span class=\"highlighted\">locals</span>, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> <span class=\"highlighted\">and</span> <span class=\"highlighted\">propagation</span>");
     }
 
     private static ThrowingConsumer<String> hitsHaveCorrectWordHighlighted(AtomicInteger matches, String word,

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -368,7 +368,7 @@ class SearchServiceTest {
                         .allSatisfy(hitsHaveCorrectWordHighlighted(matches, "orm", "highlighted-content")));
         assertThat(matches.get())
                 .as("Number of occurrences of 'orm' in " + result.hits().stream().map(GuideSearchHit::content).toList())
-                .isEqualTo(10);
+                .isEqualTo(14);
     }
 
     @Test
@@ -448,8 +448,8 @@ class SearchServiceTest {
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.hits()).extracting(GuideSearchHit::title)
                 .contains(
-                        // unified highlighter will still "highlight" the phrase word by word:
-                        "Duplicated context, context locals, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> <span class=\"highlighted\">and</span> <span class=\"highlighted\">propagation</span>");
+                        // fast-vector highlighter will highlight the phrase:
+                        "Duplicated context, context locals, <span class=\"highlighted\">asynchronous processing and propagation</span>");
     }
 
     @Test
@@ -477,7 +477,7 @@ class SearchServiceTest {
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.hits()).extracting(GuideSearchHit::content)
                 .containsOnly(
-                        Set.of("…Environment variable: QUARKUS_VIRTUAL_THREADS_ENABLED Show more boolean true WebSockets Client Type Default <span class=\"highlighted\">quarkus.websocket.max</span>-<span class=\"highlighted\">frame</span>-<span class=\"highlighted\">size</span>…"));
+                        Set.of("…Default <span class=\"highlighted\">quarkus.websocket.max</span>-<span class=\"highlighted\">frame</span>-<span class=\"highlighted\">size</span> The maximum amount of data that can be sent in a single <span class=\"highlighted\">frame</span>. Messages…"));
     }
 
     @Test
@@ -490,7 +490,7 @@ class SearchServiceTest {
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.hits()).extracting(GuideSearchHit::content)
                 .containsOnly(Set.of(
-                        "…io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathAggregateBuildItem Do not use directly: use instead. boolean allow No Javadoc found <span class=\"highlighted\">io.quarkus.deployment.pkg.builditem.NativeImageBuildItem</span>…"));
+                        "…allow No Javadoc found <span class=\"highlighted\">io.quarkus.deployment.pkg.builditem.NativeImageBuildItem</span> No Javadoc found Path…"));
     }
 
     @Test
@@ -503,7 +503,7 @@ class SearchServiceTest {
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.hits()).extracting(GuideSearchHit::content)
                 .containsOnly(Set.of(
-                        "…io.quarkus.deployment.builditem.nativeimage.NativeImageAllowIncompleteClasspathAggregateBuildItem Do not use directly: use instead. boolean allow No Javadoc found <span class=\"highlighted\">io.quarkus.deployment.pkg.builditem.NativeImageBuildItem</span>…"));
+                        "…allow No Javadoc found <span class=\"highlighted\">io.quarkus.deployment.pkg.builditem.NativeImageBuildItem</span> No Javadoc found Path…"));
     }
 
     @Test

--- a/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
@@ -41,53 +41,61 @@ class SynonymSearchServiceTest {
 
     @ParameterizedTest
     @MethodSource
-    void synonymsTitle(String query, String result) {
-        assertThat(searchHitSearchResult(query).hits()).extracting(GuideSearchHit::title)
-                .contains(result);
+    void synonymsTitle(String query, Set<String> expectedTitleHighlights) {
+        var hits = searchHitSearchResult(query).hits();
+        assertThat(expectedTitleHighlights)
+                .allSatisfy(expectedTitleHighlight -> {
+                    assertThat(hits)
+                            .extracting(GuideSearchHit::title)
+                            .anySatisfy(hitTitle -> assertThat(hitTitle).containsIgnoringCase(expectedTitleHighlight));
+                });
     }
 
     private List<? extends Arguments> synonymsTitle() {
         return List.of(
                 Arguments.of("REST Development Service",
-                        "<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span> Overview"),
+                        Set.of("<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>")),
                 Arguments.of("rest easy",
-                        "Writing <span class=\"highlighted\">REST</span> Services with Quarkus <span class=\"highlighted\">REST</span> (formerly <span class=\"highlighted\">RESTEasy</span> Reactive)"),
+                        Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")),
                 Arguments.of("vertx",
-                        "<span class=\"highlighted\">Vert.x</span> Reference Guide"),
+                        Set.of("<span class=\"highlighted\">Vert.x</span>")),
                 Arguments.of("rest api",
-                        "Writing <span class=\"highlighted\">REST</span> Services with Quarkus <span class=\"highlighted\">REST</span> (formerly <span class=\"highlighted\">RESTEasy</span> Reactive)"),
+                        Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")),
                 Arguments.of("config",
-                        "All <span class=\"highlighted\">configuration</span> options"),
+                        Set.of("<span class=\"highlighted\">configuration</span>")),
                 Arguments.of("config option",
-                        "All <span class=\"highlighted\">configuration</span> <span class=\"highlighted\">options</span>"),
+                        Set.of("<span class=\"highlighted\">configuration</span> <span class=\"highlighted\">options</span>")),
                 Arguments.of("jpa",
-                        "Using Hibernate ORM and <span class=\"highlighted\">Jakarta</span> <span class=\"highlighted\">Persistence</span>"));
+                        Set.of("<span class=\"highlighted\">Jakarta</span> <span class=\"highlighted\">Persistence</span>")));
     }
 
     @ParameterizedTest
     @MethodSource
-    void synonymsContent(String query, Set<String> result) {
-        assertThat(searchHitSearchResult(query).hits()).flatExtracting(GuideSearchHit::content)
-                .containsAll(result);
+    void synonymsContent(String query, Set<String> expectedContentHighlights) {
+        var hits = searchHitSearchResult(query).hits();
+        assertThat(expectedContentHighlights)
+                .allSatisfy(expectedContentHighlight -> {
+                    assertThat(hits)
+                            .flatExtracting(GuideSearchHit::content)
+                            .anySatisfy(hitTitle -> assertThat(hitTitle).containsIgnoringCase(expectedContentHighlight));
+                });
     }
 
     private List<? extends Arguments> synonymsContent() {
         return List.of(
                 Arguments.of("Development Service",
-                        Set.of("…also offer <span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>.…",
-                                "…In this case, before starting a container, <span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span> for AMQP looks for a container with the quarkus-<span class=\"highlighted\">dev</span>-<span class=\"highlighted\">service</span>-amqp…")),
+                        Set.of("<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>",
+                                "<span class=\"highlighted\">dev</span>-<span class=\"highlighted\">service</span>-amqp")),
                 Arguments.of("dev Service",
-                        Set.of("…also offer <span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>.…",
-                                "…In this case, before starting a container, <span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span> for AMQP looks for a container with the quarkus-<span class=\"highlighted\">dev</span>-<span class=\"highlighted\">service</span>-amqp…")),
+                        Set.of("<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>",
+                                "<span class=\"highlighted\">dev</span>-<span class=\"highlighted\">service</span>-amqp")),
                 Arguments.of("rest easy",
-                        Set.of("…Writing <span class=\"highlighted\">REST</span> Services with Quarkus <span class=\"highlighted\">REST</span> (formerly <span class=\"highlighted\">RESTEasy</span> Reactive) This guide explains how to write…",
-                                "…We recommend doing so at your application entry point boundaries like your <span class=\"highlighted\">REST</span> endpoint controllers.…")),
+                        Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")),
                 Arguments.of("vertx",
-                        Set.of("…}\n\n} You can inject either the: <span class=\"highlighted\">io.vertx.core.Vertx</span> instance exposing the bare <span class=\"highlighted\">Vert.x</span> API <span class=\"highlighted\">io.vertx.mutiny.core.Vertx</span>…",
-                                "…Access the <span class=\"highlighted\">Vert.x</span> instance To access the managed <span class=\"highlighted\">Vert.x</span> instance, add the quarkus-<span class=\"highlighted\">vertx</span> extension to…")),
+                        Set.of("<span class=\"highlighted\">io.vertx.core.Vertx</span>",
+                                "<span class=\"highlighted\">Vert.x</span>", "<span class=\"highlighted\">vertx</span>")),
                 Arguments.of("rest api",
-                        Set.of("…Writing <span class=\"highlighted\">REST</span> Services with Quarkus <span class=\"highlighted\">REST</span> (formerly <span class=\"highlighted\">RESTEasy</span> Reactive) This guide explains how to write…",
-                                "…We recommend doing so at your application entry point boundaries like your <span class=\"highlighted\">REST</span> endpoint controllers.…")));
+                        Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")));
     }
 
     private static SearchResult<GuideSearchHit> searchHitSearchResult(String q) {

--- a/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
@@ -54,7 +54,7 @@ class SynonymSearchServiceTest {
     private List<? extends Arguments> synonymsTitle() {
         return List.of(
                 Arguments.of("REST Development Service",
-                        Set.of("<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>")),
+                        Set.of("<span class=\"highlighted\">Dev Services</span>")),
                 Arguments.of("rest easy",
                         Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")),
                 Arguments.of("vertx",
@@ -64,9 +64,9 @@ class SynonymSearchServiceTest {
                 Arguments.of("config",
                         Set.of("<span class=\"highlighted\">configuration</span>")),
                 Arguments.of("config option",
-                        Set.of("<span class=\"highlighted\">configuration</span> <span class=\"highlighted\">options</span>")),
+                        Set.of("<span class=\"highlighted\">configuration options</span>")),
                 Arguments.of("jpa",
-                        Set.of("<span class=\"highlighted\">Jakarta</span> <span class=\"highlighted\">Persistence</span>")));
+                        Set.of("<span class=\"highlighted\">Jakarta Persistence</span>")));
     }
 
     @ParameterizedTest
@@ -84,11 +84,11 @@ class SynonymSearchServiceTest {
     private List<? extends Arguments> synonymsContent() {
         return List.of(
                 Arguments.of("Development Service",
-                        Set.of("<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>",
-                                "<span class=\"highlighted\">dev</span>-<span class=\"highlighted\">service</span>-amqp")),
+                        Set.of("<span class=\"highlighted\">Dev Services</span>",
+                                "<span class=\"highlighted\">dev-service</span>-amqp")),
                 Arguments.of("dev Service",
-                        Set.of("<span class=\"highlighted\">Dev</span> <span class=\"highlighted\">Services</span>",
-                                "<span class=\"highlighted\">dev</span>-<span class=\"highlighted\">service</span>-amqp")),
+                        Set.of("<span class=\"highlighted\">Dev Services</span>",
+                                "<span class=\"highlighted\">dev-service</span>-amqp")),
                 Arguments.of("rest easy",
                         Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")),
                 Arguments.of("vertx",
@@ -101,7 +101,10 @@ class SynonymSearchServiceTest {
     private static SearchResult<GuideSearchHit> searchHitSearchResult(String q) {
         return given()
                 .queryParam("q", q)
-                .queryParam("contentSnippets", 2)
+                // Bumping the number of snippets to give low-score matching terms more chance to appear in highlights.
+                // This is fine because these tests are not about relevance,
+                // just about checking that synonyms are detected correctly.
+                .queryParam("contentSnippets", 10)
                 .when().get(GUIDES_SEARCH)
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
I couldn't reproduce the same amount of slowness local as in prod, but I suspect hardware might be to blame... Heap size for OpenSearch -- as well as the app --  is the same as in prod.

In any case, search was still relatively slow on my machine at ~100ms per query. Disabling highlighting brought me to 10ms, proving that, as expected, highlighting is to blame.

So I switched to the fast-vector highlighter and saw a small improvement: instead of ~100ms, queries now take ~50 to ~70ms (still on my laptop). I had to remove stop-words filters and change the boundary scanner, but otherwise highlighted snippets seem similar.

Hopefully the improvement will be similar in prod.

I also added a force-merge after indexing because... why not. I experimented with concurrent fragment search, but this didn't provide a significant speedup.