### PR TITLE
Update to OpenSearch 2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <version.formatter.plugin>2.24.1</version.formatter.plugin>
     <version.impsort-maven-plugin>1.12.0</version.impsort-maven-plugin>
     <!-- This version needs to match the version in src/main/docker/opensearch-custom.Dockerfile -->
-    <version.opensearch>2.17</version.opensearch>
+    <version.opensearch>2.18</version.opensearch>
     <version.quarkus-web-bundler>1.7.3</version.quarkus-web-bundler>
   </properties>
   <dependencyManagement>

--- a/src/main/docker/opensearch-custom.Dockerfile
+++ b/src/main/docker/opensearch-custom.Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.17.1
+FROM opensearchproject/opensearch:2.18.0
 
 # Workaround for https://github.com/opensearch-project/opensearch-devops/issues/97
 RUN chmod -R go=u /usr/share/opensearch

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,7 +67,7 @@ quarkus.rest.path=/api
 # Hibernate Search
 ########################
 # This version needs to match the version in src/main/docker/opensearch-custom.Dockerfile
-quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.17
+quarkus.hibernate-search-standalone.elasticsearch.version=opensearch:2.18
 # Not using :latest here as a workaround until we get https://github.com/quarkusio/quarkus/pull/38896
 quarkus.elasticsearch.devservices.image-name=opensearch-custom:${maven.version.opensearch}
 quarkus.elasticsearch.devservices.java-opts=${PROD_OPENSEARCH_JAVA_OPTS}


### PR DESCRIPTION
Tests in Hibernate Search passed. 
Looking at the release notes: https://github.com/opensearch-project/OpenSearch/releases/tag/2.18.0 I didn't see anything of particular interest (except that now there's a phone analyzer soooo if we need to search for phone numbers ... 😃)