### PR TITLE
Revert "Reduce side of bulks when indexing in dev, tests and prod"

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,10 +72,10 @@ quarkus.hibernate-search-standalone.elasticsearch.version=${maven.distribution.s
 quarkus.elasticsearch.devservices.image-name=${maven.name.search.backend}:${maven.version.search.backend}
 quarkus.elasticsearch.devservices.java-opts=${PROD_ES_JAVA_OPTS}
 # Limit parallelism of indexing, because the search backend can only handle so many documents in its buffers.
-# This leads to at most 8*12=96 documents being indexed in parallel, which should be plenty
+# This leads to at most 8*20=160 documents being indexed in parallel, which should be plenty
 # given how large our documents can be.
 INDEXING_QUEUE_COUNT=8
-INDEXING_BULK_SIZE=12
+INDEXING_BULK_SIZE=20
 quarkus.hibernate-search-standalone.elasticsearch.indexing.queue-count=${INDEXING_QUEUE_COUNT}
 quarkus.hibernate-search-standalone.elasticsearch.indexing.max-bulk-size=${INDEXING_BULK_SIZE}
 # We need to apply a custom search backend mapping to exclude very large fields from the _source


### PR DESCRIPTION
This reverts commit c24d1804c6edf05e518ab27b8c6740df362ccf05.

It didn't solve anything, and probably wasn't relevant since the failure seems to happen when searching (?!)