### PR TITLE
Use correct property name for deprecation indexing

### DIFF
--- a/src/main/kubernetes/openshift.yml
+++ b/src/main/kubernetes/openshift.yml
@@ -112,7 +112,7 @@ spec:
             - name: cluster.routing.allocation.disk.threshold_enabled
               value: 'false'
             # Disable more plugins/features that we do not use:
-            - name: 'cluster.deprecation_indexing'
+            - name: 'cluster.deprecation_indexing.enabled'
               value: 'false'
             - name: 'xpack.profiling.enabled'
               value: 'false'


### PR DESCRIPTION
i.e. add missing `enabled` to the cluster.deprecation_indexing.enabled