### PR TITLE
Include part of the guide body that has unexpected formatting in the logged message

### DIFF
--- a/src/main/java/io/quarkus/search/app/hibernate/InputProviderHtmlBodyTextBridge.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/InputProviderHtmlBodyTextBridge.java
@@ -33,8 +33,8 @@ public class InputProviderHtmlBodyTextBridge implements ValueBridge<InputProvide
                     return encode(content);
                 } else {
                     Log.warnf(
-                            "Was unable to find the content section of a guide. Using whole document as text. %s",
-                            provider);
+                            "Was unable to find the content section of a guide. Using whole document as text. %s Document starts with: %.10000s",
+                            provider, body.toString());
                     return encode(body);
                 }
             }


### PR DESCRIPTION
Not sure if that's worth it or not (it'll log up to 10k chars)...  but I noticed this again when looking at the recent staging logs: https://github.com/quarkusio/search.quarkus.io/issues/319#issuecomment-2507958384 

But looking at the files it points to, those seem fine and running the app locally does not produce the warning ... so I wonder what's the content of those files if it says they aren't what we expect ... 