### PR TITLE
Reduce pressure on Elasticsearch in staging env

### DIFF
--- a/src/main/helm/values.staging.yaml
+++ b/src/main/helm/values.staging.yaml
@@ -2,7 +2,7 @@ app:
   envs:
     QUARKUS_PROFILE: 'staging'
     # Avoid overloading the rather resource-constrained Search backend instance
-    INDEXING_QUEUE_COUNT: '6'
+    INDEXING_QUEUE_COUNT: '4'
     INDEXING_BULK_SIZE: '10'
   resources:
     limits:


### PR DESCRIPTION
As discussed, the previous config seems to lead to indexing failures in the staging environment due to Elasticsearch tripping memory-related circuit breakers and/or timing out.