### PR TITLE
Experiments: Add possible suggestion to the empty results response

### DIFF
--- a/src/main/java/io/quarkus/search/app/dto/SearchResult.java
+++ b/src/main/java/io/quarkus/search/app/dto/SearchResult.java
@@ -2,14 +2,44 @@ package io.quarkus.search.app.dto;
 
 import java.util.List;
 
-public record SearchResult<T>(Total total, List<T> hits) {
+import io.quarkus.logging.Log;
 
-    public SearchResult(org.hibernate.search.engine.search.query.SearchResult<T> result) {
+import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchResult;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+public record SearchResult<T>(Total total, List<T> hits, Suggestion suggestion) {
+
+    public SearchResult(ElasticsearchSearchResult<T> result) {
         this(new Total(result.total().isHitCountExact() ? result.total().hitCount() : null,
                 result.total().hitCountLowerBound()),
-                result.hits());
+                result.hits(), extractSuggestion(result));
     }
 
     public record Total(Long exact, Long lowerBound) {
+    }
+
+    public record Suggestion(String query, String highlighted) {
+    }
+
+    private static Suggestion extractSuggestion(ElasticsearchSearchResult<?> result) {
+        try {
+            JsonObject suggest = result.responseBody().getAsJsonObject("suggest");
+            if (suggest != null) {
+                JsonArray options = suggest
+                        .getAsJsonArray("didYouMean")
+                        .get(0).getAsJsonObject()
+                        .getAsJsonArray("options");
+                if (options != null && !options.isEmpty()) {
+                    JsonObject suggestion = options.get(0).getAsJsonObject();
+                    return new Suggestion(suggestion.get("text").getAsString(), suggestion.get("highlighted").getAsString());
+                }
+            }
+        } catch (RuntimeException e) {
+            // Though it shouldn't happen, just in case we will catch any exceptions and return no suggestions:
+            Log.warnf(e, "Failed to extract suggestion: %s" + e.getMessage());
+        }
+        return null;
     }
 }

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -61,6 +61,7 @@ public class Guide {
 
     @I18nFullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.FAST_VECTOR, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nFullTextField(name = "fullContent_autocomplete", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
+    @I18nFullTextField(name = "fullContent_suggestion", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzerPrefix = AnalysisConfigurer.SUGGESTION, searchAnalyzerPrefix = AnalysisConfigurer.SUGGESTION)
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
     public I18nData<InputProvider> htmlFullContentProvider = new I18nData<>();
 

--- a/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/AnalysisConfigurer.java
@@ -25,6 +25,7 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 
     public static final String DEFAULT = "basic_analyzer";
     public static final String DEFAULT_SEARCH = DEFAULT + "_search";
+    public static final String SUGGESTION = "suggestion";
     public static final String AUTOCOMPLETE = "autocomplete";
     public static final String SORT = "sort";
     // This is simplified by assuming no default package, lowercase package names and capitalized class name,
@@ -34,6 +35,10 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 
     public static String defaultAnalyzer(Language language) {
         return language.addSuffix(DEFAULT);
+    }
+
+    public static String suggestionAnalyzer(Language language) {
+        return language.addSuffix(SUGGESTION);
     }
 
     public static String defaultSearchAnalyzer(Language language) {
@@ -101,6 +106,16 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "asciifolding")
                 .charFilters("html_strip");
 
+        context.analyzer(suggestionAnalyzer(language)).custom()
+                .tokenizer("standard")
+                .tokenFilters(
+                        // To make all words in lowercase.
+                        "lowercase",
+                        // To convert characters into ascii ones, e.g. à to a or ę to e etc.
+                        "asciifolding",
+                        "shingle")
+                .charFilters("html_strip");
+
         // The analyzer to be applied to the user-input text.
         context.analyzer(defaultSearchAnalyzer(language)).custom()
                 .tokenizer("standard")
@@ -158,6 +173,16 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "icu_normalizer",
                         "html_strip");
 
+        context.analyzer(suggestionAnalyzer(language)).custom()
+                .tokenizer("kuromoji_tokenizer")
+                .tokenFilters(
+                        // To make all words in lowercase.
+                        "lowercase",
+                        // To convert characters into ascii ones, e.g. à to a or ę to e etc.
+                        "asciifolding",
+                        "shingle")
+                .charFilters("html_strip");
+
         context.analyzer(defaultSearchAnalyzer(language)).custom()
                 .tokenizer("kuromoji_tokenizer")
                 .tokenFilters(
@@ -209,6 +234,16 @@ public class AnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
                         "smartcn_stop",
                         regularStemmerFilter(language),
                         "asciifolding")
+                .charFilters("html_strip");
+
+        context.analyzer(suggestionAnalyzer(language)).custom()
+                .tokenizer("smartcn_tokenizer")
+                .tokenFilters(
+                        // To make all words in lowercase.
+                        "lowercase",
+                        // To convert characters into ascii ones, e.g. à to a or ę to e etc.
+                        "asciifolding",
+                        "shingle")
                 .charFilters("html_strip");
 
         // The analyzer to be applied to the user-input text.

--- a/src/main/resources/web/app/qs-form.ts
+++ b/src/main/resources/web/app/qs-form.ts
@@ -6,10 +6,12 @@ import {LocalSearch} from "./local-search";
 export const QS_START_EVENT = 'qs-start';
 export const QS_RESULT_EVENT = 'qs-result';
 export const QS_NEXT_PAGE_EVENT = 'qs-next-page';
+export const QS_QUERY_SUGGESTION_EVENT = 'qs-query-suggestion';
 
 export interface QsResult {
   hits: QsHit[];
   hasMoreHits: boolean;
+  suggestion: QsSuggestion;
 }
 
 export interface QsHit {
@@ -19,6 +21,11 @@ export interface QsHit {
   keywords: string | undefined;
   content: string | undefined;
   type: string | undefined;
+}
+
+export interface QsSuggestion {
+  query: string;
+  highlighted: string;
 }
 
 /**
@@ -106,6 +113,7 @@ export class QsForm extends LitElement {
     LocalSearch.enableLocalSearch();
     const formElements = this._getFormElements();
     this.addEventListener(QS_NEXT_PAGE_EVENT, this._handleNextPage);
+    this.addEventListener(QS_QUERY_SUGGESTION_EVENT, this._handleQuerySuggestion)
     formElements.forEach((el) => {
       const eventName = this._isInput(el) ? 'input' : 'change';
       el.addEventListener(eventName, this._handleInputChange);
@@ -118,6 +126,7 @@ export class QsForm extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener(QS_NEXT_PAGE_EVENT, this._handleNextPage);
+    this.removeEventListener(QS_QUERY_SUGGESTION_EVENT, this._handleQuerySuggestion)
     const formElements = this._getFormElements();
     formElements.forEach(el => {
       const eventName = this._isInput(el) ? 'input' : 'change';
@@ -218,6 +227,15 @@ export class QsForm extends LitElement {
   private _handleNextPage = (e: CustomEvent) => {
     this._page++;
     this._search();
+  }
+
+  private _handleQuerySuggestion = (e: CustomEvent) => {
+    this._getFormElements().forEach((el) => {
+      if (this._isInput(el) && el.name === 'q') {
+        el.value = e.detail.suggestion.query;
+      }
+    });
+    this._handleInputChange(e);
   }
 
   private _isInput(el: HTMLFormElement) {

--- a/src/main/resources/web/app/qs-target.ts
+++ b/src/main/resources/web/app/qs-target.ts
@@ -1,9 +1,10 @@
 import {LitElement, html, css, unsafeCSS} from 'lit';
 import {customElement, property, state, queryAll} from 'lit/decorators.js';
 import './qs-guide'
-import {QS_NEXT_PAGE_EVENT, QS_RESULT_EVENT, QS_START_EVENT, QsResult} from "./qs-form";
+import {QS_NEXT_PAGE_EVENT, QS_QUERY_SUGGESTION_EVENT, QS_RESULT_EVENT, QS_START_EVENT, QsResult} from "./qs-form";
 import debounce from 'lodash/debounce';
 import icons from "./assets/icons";
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 
 /**
@@ -41,6 +42,14 @@ export class QsTarget extends LitElement {
       font-style: italic;
       text-align: center;
       background: var(--empty-background-color, #F0CA4D);
+      
+      .suggestion {
+        text-decoration: underline;
+        cursor: pointer;
+        .highlighted {
+          font-weight: bold;
+        }
+      }
     }
 
     .search-result-title {
@@ -95,11 +104,20 @@ export class QsTarget extends LitElement {
   render() {
     if (this._result?.hits) {
       if (this._result.hits.length === 0) {
-        return html`
+        if (this._result.suggestion) {
+          return html`
+            <div id="qs-target" class="no-hits">
+              <p>Sorry, no ${this.type}s matched your search.
+                Did you mean <span class="suggestion" @click=${this._querySuggestion}>${unsafeHTML(this._result.suggestion.highlighted)}</span>?</p>
+            </div>
+          `;
+        } else {
+          return html`
           <div id="qs-target" class="no-hits">
             <p>Sorry, no ${this.type}s matched your search. Please try again.</p>
           </div>
         `;
+        }
       }
       const result = this._result.hits.map(i => this._renderHit(i));
       return html`
@@ -193,5 +211,9 @@ export class QsTarget extends LitElement {
 
   private _loadingEnd = () => {
     this._loading = false;
+  }
+
+  private _querySuggestion() {
+    this._form.dispatchEvent(new CustomEvent(QS_QUERY_SUGGESTION_EVENT, {detail: {suggestion: this._result.suggestion}}));
   }
 }

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -485,6 +485,62 @@ class SearchServiceTest {
                         "<span class=\"highlighted\">Duplicated</span> <span class=\"highlighted\">context</span>, <span class=\"highlighted\">context</span> <span class=\"highlighted\">locals</span>, <span class=\"highlighted\">asynchronous</span> <span class=\"highlighted\">processing</span> <span class=\"highlighted\">and</span> <span class=\"highlighted\">propagation</span>");
     }
 
+    /**
+     * Since there are some typos, the search results should include a suggestion with the text that would produce some results.
+     */
+    @Test
+    void suggestion() {
+        var result = given()
+                .queryParam("q", "hiberante search")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+        assertThat(result.suggestion().query())
+                .isEqualTo("hibernate search");
+
+        result = given()
+                .queryParam("q", "aplication")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+        assertThat(result.suggestion().query())
+                .isEqualTo("application");
+
+        result = given()
+                .queryParam("q", "Configuring your aplication")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+        assertThat(result.suggestion().query())
+                .isEqualTo("configuring your application");
+
+        result = given()
+                .queryParam("q", "vertex")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+        assertThat(result.suggestion().query())
+                .isEqualTo("vert.x");
+    }
+
+    /**
+     * As the query text is already fine, and matches the existing tokens, no suggestion is expected.
+     */
+    @Test
+    void noSuggestion() {
+        var result = given()
+                .queryParam("q", "hibernate search")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+        assertThat(result.suggestion()).isNull();
+    }
+
     private static ThrowingConsumer<String> hitsHaveCorrectWordHighlighted(AtomicInteger matches, String word,
             String cssClass) {
         return sentence -> {


### PR DESCRIPTION
Fixes #306 

Hey @yrodiere 

I was going through some tickets at HSEARCH 😃 and noticed one submitted by the community about suggesters, but without much info. Hence, I thought I'd take a closer look at the suggesters before closing the ticket 🙈 and it turned out to be an interesting feature. This PR tests how we could leverage from it in search.quarkus.io. 
While at it, I thought: should we give users a way to manipulate the request JSON before we send it (like in this PR we are adding another top-level element to the JSON, so adding things through e.g. a JSON predicate, wouldn't really work...)

![image](https://github.com/user-attachments/assets/336825b1-922e-4a21-a922-ad43b48bf48c)


Some links:
- https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
- https://lucene.apache.org/core/10_0_0/suggest/index.html