### PR TITLE
Increase indexing timeout

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ quarkusio.localized.ja.git-uri=https://github.com/quarkusio/ja.quarkus.io.git
 ########################
 fetching.parallelism=8
 fetching.timeout=10m
-indexing.timeout=10m
+indexing.timeout=15m
 # Index at 00:00 UTC every day
 # The time was selected to minimize impact on users:
 # In winter this would be: Paris 01:00, New Delhi: 05:30, New York: 19:00, Beijing: 08:00, Los Angeles: 16:00


### PR DESCRIPTION
as now, it also includes Quarkiverse guides, increasing the overall indexing time. Looking at staging we've got:

```
07:55:27 INFO [i.qu.se.ap.hi.StreamMassIndexingLoggingMonitor] Mass indexing is going to index an entity stream. Total is not known at this point.
....
08:05:22 INFO [i.qu.se.ap.hi.StreamMassIndexingLoggingMonitor] Mass indexing progress: indexed 6150 entities in 513720 ms.
08:05:27 ERROR [o.hi.se.ma.po.ma.im.PojoMassIndexingNotifier] HSEARCH000062: Mass indexing received interrupt signal: aborting.
```