### PR TITLE
Adjust the condition of not returning index.html

### DIFF
--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -3,7 +3,6 @@ package io.quarkus.search.app;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Max;
@@ -21,8 +20,6 @@ import io.quarkus.search.app.entity.Language;
 import io.quarkus.search.app.entity.QuarkusVersionAndLanguageRoutingBinder;
 import io.quarkus.search.app.quarkusio.QuarkusIO;
 
-import io.quarkus.runtime.LaunchMode;
-
 import org.hibernate.search.engine.search.common.BooleanOperator;
 import org.hibernate.search.engine.search.common.ValueModel;
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryFlag;
@@ -30,8 +27,6 @@ import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.resteasy.reactive.RestQuery;
-
-import io.vertx.ext.web.Router;
 
 @ApplicationScoped
 @Path("/")
@@ -44,16 +39,6 @@ public class SearchService {
 
     @Inject
     SearchMapping searchMapping;
-
-    public void init(@Observes Router router) {
-        if (LaunchMode.current().isDevOrTest()) {
-            return;
-        }
-        // DISABLE the index.html route in production
-        router.getWithRegex("/(index\\.html)?").order(Integer.MIN_VALUE).handler(rc -> {
-            rc.response().setStatusCode(404).end();
-        });
-    }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/io/quarkus/search/app/ui/SearchUiConfig.java
+++ b/src/main/java/io/quarkus/search/app/ui/SearchUiConfig.java
@@ -1,0 +1,11 @@
+package io.quarkus.search.app.ui;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "search.ui")
+public interface SearchUiConfig {
+
+    @WithDefault("true")
+    boolean enabled();
+}

--- a/src/main/java/io/quarkus/search/app/ui/SearchUiService.java
+++ b/src/main/java/io/quarkus/search/app/ui/SearchUiService.java
@@ -1,0 +1,24 @@
+package io.quarkus.search.app.ui;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import io.vertx.ext.web.Router;
+
+@ApplicationScoped
+public class SearchUiService {
+
+    @Inject
+    SearchUiConfig searchUiConfig;
+
+    public void init(@Observes Router router) {
+        if (searchUiConfig.enabled()) {
+            return;
+        }
+        // DISABLE the index.html route in production
+        router.getWithRegex("/(index\\.html)?").order(Integer.MIN_VALUE).handler(rc -> {
+            rc.response().setStatusCode(404).end();
+        });
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,10 @@ quarkusio.localized.cn.web-uri=https://cn.quarkus.io/
 quarkusio.localized.cn.git-uri=https://github.com/quarkusio/cn.quarkus.io.git
 quarkusio.localized.ja.web-uri=https://ja.quarkus.io/
 quarkusio.localized.ja.git-uri=https://github.com/quarkusio/ja.quarkus.io.git
+# We do not want to show the search index page in production as it is there only for testing purposes:
+%prod.search.ui.enabled=false
+# and we explicitly override it for the staging profile (see `%staging.quarkus.config.profile.parent`):
+%staging.search.ui.enabled=true
 
 ########################
 # Indexing configuration


### PR DESCRIPTION
to not rely on launch mode but on profiles instead. This way staging, that also runs in a normal launch mode can benefit from the index search page