### PR TITLE
Simplify configuration of Quarkiverse.io fetching

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,7 +74,7 @@ _DEV_QUARKUSIO_WEB_URI=http://localhost:4000
 ----
 
 By default, in dev mode, any parsing/indexing warnings and errors are going to be simply logged.
-But in case you want to get index errors reported to a GitHub issue, next properties should be added:
+But in case you want to get index errors reported to a GitHub issue, the following properties should be added:
 [source,properties]
 ----
 _DEV_INDEXING_REPORTING_TYPE=github-issue
@@ -106,11 +106,9 @@ add the following properties to your `.env` file:
 
 [source,properties]
 ----
+_DEV_QUARKIVERSEIO_SOURCE=github-artifact
 # see about tokens https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 QUARKIVERSEIO_GITHUB_ARTIFACT_TOKEN={your-generated-github-token}
-QUARKIVERSEIO_GITHUB_ARTIFACT_REPOSITORY=quarkiverse/quarkiverse-docs
-QUARKIVERSEIO_GITHUB_ARTIFACT_ACTION_NAME=Publish website
-QUARKIVERSEIO_GITHUB_ARTIFACT_ARTIFACT_NAME=github-pages
 ----
 
 [[testing]]

--- a/src/main/java/io/quarkus/search/app/quarkiverseio/QuarkiverseIOConfig.java
+++ b/src/main/java/io/quarkus/search/app/quarkiverseio/QuarkiverseIOConfig.java
@@ -10,30 +10,39 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "quarkiverseio")
 public interface QuarkiverseIOConfig {
 
-    Optional<Zip> zip();
+    @WithDefault("github-artifact")
+    SourceType source();
 
-    Optional<GithubArtifact> githubArtifact();
+    enum SourceType {
+        NONE,
+        GITHUB_ARTIFACT,
+        ZIP
+    }
 
-    @WithDefault("true")
-    boolean enabled();
+    Zip zip();
+
+    GithubArtifact githubArtifact();
 
     @WithDefault("https://docs.quarkiverse.io/")
     URI baseUri();
 
     interface GithubArtifact {
-        String token();
+        // Only necessary if source = github-artifact
+        Optional<String> token();
 
+        @WithDefault("quarkiverse/quarkiverse-docs")
         String repository();
 
-        //@WithDefault( "Publish website" )
+        @WithDefault("Publish website")
         String actionName();
 
-        //@WithDefault( "github-pages" )
+        @WithDefault("github-pages")
         String artifactName();
     }
 
     interface Zip {
-        Path path();
+        // Only necessary if source = zip
+        Optional<Path> path();
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -118,8 +118,12 @@ quarkus.hibernate-search-standalone.elasticsearch.max-connections=90
 # Allow localhost in particular
 %dev,staging.quarkus.http.cors.origins=/.*/
 %dev,staging.quarkus.http.header."Access-Control-Allow-Private-Network".value=true
-# disable indexing and fetching of html quarkiverse guides in tests/dev
-%dev,test.quarkiverseio.enabled=false
+# We don't want dev mode and tests to rely on remote services (GitHub, ...), so
+# - for dev mode we index a zip included in the test resources.
+%dev.quarkiverseio.source=zip
+# - for tests we just disable Quarkiverdse indexing,
+#   and use the zip included in the test resources in some specific tests.
+%test.quarkiverseio.source=none
 %dev,test.quarkiverseio.zip.path=${maven.project.testResourceDirectory}/github-pages.zip
 
 ########################

--- a/src/test/java/io/quarkus/search/app/SearchServiceQuarkiverseTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceQuarkiverseTest.java
@@ -36,7 +36,7 @@ class SearchServiceQuarkiverseTest {
     public static class Profile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
-            return Map.of("quarkiverseio.enabled", "true");
+            return Map.of("quarkiverseio.source", "zip");
         }
     }
 


### PR DESCRIPTION
I had some trouble setting this up in my dev env, so I thought this could make sense...

`quarkiverseio.source` can be set to `none`, `zip` or `github-artifact`, which will get the ball rolling provided you set your token (for `github-artifact`) or path (for `zip`).

Also, use the `_DEV_` prefix for the recommended options to download Quarkiverse in dev mode, otherwise the .env file might affect tests.

NOTE: Upon merging, we may need to clean up the staging config. I think removing everything except the token from the config map should do the trick.