### PR TITLE
Improve relative relevance of quarkus.io guides vs quarkiverse.io guides

### DIFF
--- a/src/test/java/io/quarkus/search/app/testsupport/GuideRef.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/GuideRef.java
@@ -32,6 +32,8 @@ public record GuideRef(String nameAfterRestRenaming, String nameBeforeRestRenami
     public static final GuideRef ALL_BUILDITEMS = create("all-builditems");
     public static final GuideRef QUARKIVERSE_AMAZON_S3 = createQuarkiverse(
             "https://docs.quarkiverse.io/quarkus-amazon-services/dev/amazon-s3.html");
+    public static final GuideRef QUARKIVERSE_HIBERNATE_SEARCH_EXTRAS = createQuarkiverse(
+            "https://docs.quarkiverse.io/quarkus-hibernate-search-extras/dev/index.html");
     // NOTE: when adding new constants here, don't forget to run the main() method in QuarkusIOSample
     // to update the QuarkusIO sample in src/test/resources.
 


### PR DESCRIPTION
So that Quarkiverse guides are generally lower in the result list, but are not sent down to oblivion either.

See examples below (you won't believe the last one! cc @gsmet)

## Query: `hibernate` (no change)

![image](https://github.com/user-attachments/assets/46283637-3ea7-4a2d-8072-97f0409fa1ab)

## Query: `search`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/a6c5c26e-547b-48f6-a00d-38ef97461065) | ![image](https://github.com/user-attachments/assets/32a5182f-98b6-4e50-b73c-97e6f2fd5bc4)  |

## Query: `jdbc`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/36a76cce-d3d5-49ab-804e-c079f84fde0b)  | ![image](https://github.com/user-attachments/assets/3e24ec13-0e6e-46bf-9c7d-44aafeefd5d6)  |

## Query: `hibernate search`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/646385f5-0322-4b52-843f-61b2a7ae47cc)  | ![image](https://github.com/user-attachments/assets/6032f782-9e3d-4050-b9aa-c1ff4dbabc4a)  |


## Query: `hibernate search aws`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/349bbe64-9fd9-4c1c-ba9d-08f58074a46d)  | ![image](https://github.com/user-attachments/assets/ffb7284d-51f5-4c51-a85f-980b8567a13b)  |

## Query: `hibernate search extra`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/a21a0918-6dd1-4574-bcbf-ebbbe6ee166f)  | ![image](https://github.com/user-attachments/assets/596a9e1c-3a87-4036-9852-4e9131fa4820)  |


## Query: `github`

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/ba36d9ef-3ffb-4f9a-8748-3cb6800b9b99)  | ![image](https://github.com/user-attachments/assets/d392f75d-3de0-450a-a6d5-57d52818014f) |




