### PR TITLE
Increase memory limit for staging / Increase health probe thresholds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.5.2</surefire-plugin.version>
     <!-- Match the memory limits to the ones set for the staging profile (see src/main/helm/values.staging.yaml). -->
-    <test.jvm.args>-Xms1g -Xmx1g</test.jvm.args>
+    <test.jvm.args>-Xms1536m -Xmx1536m</test.jvm.args>
     <version.docker.plugin>0.45.1</version.docker.plugin>
     <version.formatter.plugin>2.24.1</version.formatter.plugin>
     <version.impsort-maven-plugin>1.12.0</version.impsort-maven-plugin>

--- a/src/main/helm/values.staging.yaml
+++ b/src/main/helm/values.staging.yaml
@@ -9,7 +9,7 @@ app:
     # This should ensure that we will discover potential memory issues on staging sooner (when running builds locally).
     limits:
       cpu: 1000m
-      memory: 1Gi
+      memory: 1.5Gi
     requests:
       cpu: 250m
       memory: 500Mi


### PR DESCRIPTION
Staging keeps struggling to get up though it got a bit further with the patch 😖. I've also increased the thresholds for health checks to more or less match the times that we've set for the `startup-probe`