### PR TITLE
Use SHA instead of versions in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
             'target/build-report.json' \
             LICENSE.txt
     - name: Upload build reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # 4.6.0
       if: always()
       with:
         name: "build-reports-${{ github.run_attempt }}-Build"
@@ -68,7 +68,7 @@ jobs:
           build-reports.zip
         retention-days: 7
     - name: Produce report and add it as job summary
-      uses: quarkusio/action-build-reporter@main
+      uses: quarkusio/action-build-reporter@02e2aea3728e6f31199387eeba0dcdbd18b75159 # main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         build-reports-artifacts-path: .


### PR DESCRIPTION
Missed that other PR by a minute 😄 

not sure about the `quarkusio/action-build-reporter`, do we keep its version floating?