### PR TITLE
Remove OpenSearch profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,6 @@
     <version.docker.plugin>0.45.1</version.docker.plugin>
     <version.formatter.plugin>2.25.0</version.formatter.plugin>
     <version.impsort-maven-plugin>1.12.0</version.impsort-maven-plugin>
-    <!-- This version needs to match the version in src/main/docker/opensearch-custom.Dockerfile -->
-    <version.opensearch>2.18</version.opensearch>
     <!-- This version needs to match the version in src/main/docker/elasticsearch-custom.Dockerfile -->
     <version.elasticsearch>8.17</version.elasticsearch>
     <version.quarkus-web-bundler>1.8.1</version.quarkus-web-bundler>
@@ -419,19 +417,6 @@
     </plugins>
   </build>
   <profiles>
-    <profile>
-      <!--
-        A simple profile to run the tests against an OpenSearch distribution of the search backend.
-        Keep in mind that this will only work for the tests, not for deploying the app to OpenShift.
-      -->
-      <id>opensearch</id>
-      <properties>
-        <search.backend.dockerfile>${project.basedir}/src/main/docker/opensearch-custom.Dockerfile</search.backend.dockerfile>
-        <search.backend.dockerversion>${version.opensearch}</search.backend.dockerversion>
-        <search.backend.dockername>opensearch-custom</search.backend.dockername>
-        <search.backend.distribution>opensearch</search.backend.distribution>
-      </properties>
-    </profile>
     <profile>
       <!-- Locked dependencies for mvnpm (Update with 'mvn io.mvnpm:locker-maven-plugin:LATEST:lock -Dunlocked') -->
       <id>locker</id>

--- a/src/main/docker/opensearch-custom.Dockerfile
+++ b/src/main/docker/opensearch-custom.Dockerfile
@@ -1,8 +1,0 @@
-FROM opensearchproject/opensearch:2.19.0
-
-# Workaround for https://github.com/opensearch-project/opensearch-devops/issues/97
-RUN chmod -R go=u /usr/share/opensearch
-
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-kuromoji
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-smartcn
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-icu


### PR DESCRIPTION
While testing with it is easy... just:
```
mvn clean install -Popensearch
```

Running the tests leads to all those issues we had with the OpenSearch backend in the first place:

```
HSEARCH400007: Elasticsearch request failed: HSEARCH400090: Elasticsearch response indicates a failure.
"reason": "[parent] Data too large, data for [\u003chttp_request\u003e] would be [1053417574/1004.6mb], which is larger than the limit of [1020054732/972.7mb], real usage: .... 
```
sooooo dropping the profile it is then 🥲 