### PR TITLE
Update to Elasticsearch 8.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <version.formatter.plugin>2.26.0</version.formatter.plugin>
     <version.impsort-maven-plugin>1.12.0</version.impsort-maven-plugin>
     <!-- This version needs to match the version in src/main/docker/elasticsearch-custom.Dockerfile -->
-    <version.elasticsearch>8.17</version.elasticsearch>
+    <version.elasticsearch>8.18</version.elasticsearch>
     <version.quarkus-web-bundler>1.8.1</version.quarkus-web-bundler>
     <!-- Configuration for the search backend used in tests by default: -->
     <search.backend.dockerfile>${project.basedir}/src/main/docker/elasticsearch-custom.Dockerfile</search.backend.dockerfile>

--- a/src/main/docker/elasticsearch-custom.Dockerfile
+++ b/src/main/docker/elasticsearch-custom.Dockerfile
@@ -1,4 +1,4 @@
-FROM elastic/elasticsearch:8.17.4
+FROM elastic/elasticsearch:8.18.0
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch analysis-kuromoji
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch analysis-smartcn

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,7 +71,7 @@ quarkus.rest.path=/api
 # Hibernate Search
 ########################
 # This version needs to match the version in src/main/docker/elasticsearch-custom.Dockerfile
-quarkus.hibernate-search-standalone.elasticsearch.version=${maven.distribution.search.backend:elastic}:${maven.version.search.backend:8.17}
+quarkus.hibernate-search-standalone.elasticsearch.version=${maven.distribution.search.backend:elastic}:${maven.version.search.backend:8.18}
 # Not using :latest here as a workaround until we get https://github.com/quarkusio/quarkus/pull/38896
 quarkus.elasticsearch.devservices.image-name=${maven.name.search.backend}:${maven.version.search.backend}
 quarkus.elasticsearch.devservices.java-opts=${PROD_ES_JAVA_OPTS}


### PR DESCRIPTION
we'll upgrade to 9.0 once it's "supported" in the Hibernate Search version included in Quarkus