### PR TITLE
Run `quarkus update`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,6 @@
     <dependency>
       <groupId>io.quarkiverse.playwright</groupId>
       <artifactId>quarkus-playwright</artifactId>
-      <version>2.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,7 +58,7 @@ indexing.batch-size=10
 ########################
 # More secure HTTP defaults
 ########################
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=https://quarkus.io,/https://.*\\\\.quarkus\\\\.io/,/https://quarkus-(.+-)?pr-.*-preview\\\\.surge\\\\.sh/,https://docs.quarkiverse.io,/https://quarkiverse-(.+-)?pr-.*-preview\\\\.surge\\\\.sh/
 quarkus.http.cors.methods=GET
 quarkus.http.header."X-Content-Type-Options".value=nosniff


### PR DESCRIPTION
I reverted to some older commit
(cc66a99955fb5f6231c09940c063d81fe4f5116b)
and ran `quarkus update`.

It found a deprecated config (CORS-related), and also an unnecessary version in dependencies (it's managed further up in the same POM).