### PR TITLE
Fix/pull quarkiverse gh filter

### DIFF
--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -96,7 +96,7 @@ public class FetchingService {
         for (GHWorkflowRun run : repository.queryWorkflowRuns()
                 .conclusion(GHWorkflowRun.Conclusion.SUCCESS)
                 .list().withPageSize(10)) {
-            if (ghConfig.actionName().equals(run.getName())) {
+            if (ghConfig.actionName().equals(run.getName()) && ghConfig.mainBranchName().equals(run.getHeadBranch())) {
                 for (GHArtifact ghArtifact : run.listArtifacts().withPageSize(5).toList()) {
                     if (ghConfig.artifactName().equals(ghArtifact.getName())) {
                         artifact = tempDir.path().resolve(ghArtifact.getName() + ".zip");

--- a/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
+++ b/src/main/java/io/quarkus/search/app/fetching/FetchingService.java
@@ -105,16 +105,15 @@ public class FetchingService {
                                 "Downloading Quarkiverse %s artifact #%s", ghConfig.artifactName(),
                                 ghArtifact.getId());
                         ghArtifact.download(is -> Files.copy(is, finalArtifact));
-                        break;
+                        return finalArtifact;
                     }
                 }
-                break;
+                Log.warnf(
+                        "The Github action run %s of %s is missing the required % artifact. Trying to find it in a previous run.",
+                        run.getId(), ghConfig.actionName(), ghConfig.artifactName());
             }
         }
-        if (artifact == null) {
-            throw new IllegalStateException("GitHub artifact " + ghConfig.artifactName() + " not found.");
-        }
-        return artifact;
+        throw new IllegalStateException("GitHub artifact " + ghConfig.artifactName() + " not found.");
     }
 
     public QuarkusIO fetchQuarkusIo(FailureCollector failureCollector) {

--- a/src/main/java/io/quarkus/search/app/quarkiverseio/QuarkiverseIOConfig.java
+++ b/src/main/java/io/quarkus/search/app/quarkiverseio/QuarkiverseIOConfig.java
@@ -38,6 +38,9 @@ public interface QuarkiverseIOConfig {
 
         @WithDefault("github-pages")
         String artifactName();
+
+        @WithDefault("main")
+        String mainBranchName();
     }
 
     interface Zip {


### PR DESCRIPTION
Checked locally and also looked at the https://api.github.com/repos/quarkiverse/quarkiverse-docs/actions/runs?status=success&per_page=10

the branch name is simply the name without any `head/` `ref/` or whatever, also the run we think caused the problem `15029020951` has the `head_branch": "quarkus-proxy-wasm",` so this should filter it out.