### PR TITLE
Use JDK 21 to build the project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,11 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
 
     - name: Cache local Maven repository
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,11 +31,11 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 21
 
     - name: Set up Helm
       uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0


### PR DESCRIPTION
Seems that the jbang script in the `quarkusio/action-build-reporter` action is using JDK 21

> Run ~/.jbang/bin/jbang --java 21 --fresh --repos 'quarkus-github-action=https://maven.pkg.github.com/quarkusio/action-build-reporter/' --repos 'mavencentral' io.quarkus.bot:action-build-reporter:999-SNAPSHOT

it also seems that in the previous builds it managed to pull the JDK:

https://github.com/quarkusio/search.quarkus.io/actions/runs/17028620561/job/48267483822

while in the more recent one https://github.com/quarkusio/search.quarkus.io/actions/runs/17201370198/job/48792463604 it failed with

> Error:  [ERROR] No suitable JDK was found for requested version: 21

since we are installing the JDK anyway... let's use the one that that jbang script can reuse instead of downloading another one ?