### PR TITLE
Allow all GitHub action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,3 @@ updates:
       workflow-actions:
         patterns:
           - "*"
-    allow:
-      - dependency-name: "actions/*"
-      - dependency-name: "redhat-actions/*"


### PR DESCRIPTION
If we're using an action, we need to keep it up to date. Dependabot is not the place to decide which action is allowed; there are organization settings for that.