### PR TITLE
Fix a typo in the staging memory config for Elasticsearch

### DIFF
--- a/src/main/helm/values.staging.yaml
+++ b/src/main/helm/values.staging.yaml
@@ -22,4 +22,4 @@ elasticsearch:
       memory: 1.5Gi
     requests:
       cpu: 250m
-      memory: 1.0Mi
+      memory: 1.0Gi


### PR DESCRIPTION
I suspect this changes nothing... but then ES probably won't fit in a container with 1mb memory 🫣 🙂 so might as well request a bit more from the start 🤞🏻 