### PR TITLE
Use search/query instead of hash to identify search params

### DIFF
--- a/src/main/resources/web/app/qs-form.ts
+++ b/src/main/resources/web/app/qs-form.ts
@@ -73,7 +73,7 @@ export class QsForm extends LitElement {
 
   constructor() {
     super();
-    const searchParams = new URLSearchParams(window.location.hash.substring(1));
+    const searchParams = new URLSearchParams(window.location.search.substring(1));
     if (searchParams.size > 0) {
       this._initialQueryStringPresent = true;
       const formElements = this._getFormElements();
@@ -99,7 +99,11 @@ export class QsForm extends LitElement {
       this._initialQueryStringPresent = false;
       this._handleInputChange(null);
     }
-    window.location.hash = this._browserData ? (new URLSearchParams(this._browserData)).toString() : window.location.hash;
+   const newSearch = this._browserData ? '?' + (new URLSearchParams(this._browserData)).toString() : '';
+   const newUrl = window.location.pathname + newSearch + window.location.hash;
+   if (window.location.pathname + window.location.search + window.location.hash !== newUrl) {
+      history.replaceState(null, '', newUrl);
+   }
     if (!this._backendData) {
       this._clearSearch();
     } else {


### PR DESCRIPTION
This is a breaking change, but I think it's a sensible one. At the moment, when you do a search on http://quarkus.io/guides, it makes a url like https://quarkus.io/guides/#q=something. I think https://quarkus.io/guides?q=something would be more expected. It should be better for SEO, and it allows hash fragments to coexist in the guides page with searches.

The naive implementation of this (which I of course implemented first) would prompt a page reload for every typed character, but using the history API should avoid that. That reload problem might be why we used hashes in the first place? 

Two pages on quarkus.io currently have links, so they'd need to be updated once this was live. We might also want to consider doing a javascript-y redirect on quarkus.io to catch any incoming # urls and convert them to the new form. (Claude coded something up to go in the opposite direction and convert ? to #, so I _think_ it's possible.)

cc @gsmet 