### PR TITLE
Grouped search by categories and relevance changes

### DIFF
--- a/src/main/java/io/quarkus/search/app/ReferenceService.java
+++ b/src/main/java/io/quarkus/search/app/ReferenceService.java
@@ -66,6 +66,15 @@ public class ReferenceService {
         return listAllValues("categories", Comparator.naturalOrder());
     }
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "List available subcategories")
+    @Path("/subcategories")
+    @CacheResult(cacheName = REFERENCE_CACHE, keyGenerator = MethodNameCacheKeyGenerator.class)
+    public List<String> subcategories() {
+        return listAllValues("subcategories", Comparator.naturalOrder());
+    }
+
     public void invalidateCaches() {
         cache.invalidateAll().subscribe().asCompletionStage().join();
     }

--- a/src/main/java/io/quarkus/search/app/SearchService.java
+++ b/src/main/java/io/quarkus/search/app/SearchService.java
@@ -1,11 +1,12 @@
 package io.quarkus.search.app;
 
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -13,6 +14,9 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import io.quarkus.search.app.dto.GroupedGuideHit;
+import io.quarkus.search.app.dto.GroupedSearchResult;
+import io.quarkus.search.app.dto.GroupedSearchResult.CategoryGroup;
 import io.quarkus.search.app.dto.GuideSearchHit;
 import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.entity.Guide;
@@ -30,6 +34,7 @@ import org.hibernate.search.engine.search.common.ValueModel;
 import org.hibernate.search.engine.search.predicate.dsl.MatchPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanPredicateClausesCollector;
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryFlag;
 import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
 import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
@@ -47,7 +52,8 @@ public class SearchService {
     private static final int TITLE_OR_SUMMARY_MAX_SIZE = 32_600;
     private static final int PAGE_SIZE = 50;
     private static final long TOTAL_HIT_COUNT_THRESHOLD = 100;
-    private static final String MAX_FOR_PERF_MESSAGE = "{jakarta.validation.constraints.Max.message} for performance reasons";
+    private static final int GROUPED_CATEGORIES_SIZE = 30;
+    public static final int GROUPED_DOCS_PER_CATEGORY = 6;
 
     @Inject
     SearchMapping searchMapping;
@@ -64,18 +70,17 @@ public class SearchService {
             @RestQuery @DefaultValue("en") Language language,
             @RestQuery @DefaultValue("highlighted") String highlightCssClass,
             @RestQuery @DefaultValue("0") @Min(0) int page,
-            @RestQuery @DefaultValue("1") @Min(0) @Max(value = 10, message = MAX_FOR_PERF_MESSAGE) int contentSnippets,
-            @RestQuery @DefaultValue("100") @Min(0) @Max(value = 200, message = MAX_FOR_PERF_MESSAGE) int contentSnippetsLength) {
+            @RestQuery List<String> excludeIds) {
         try (var session = searchMapping.createSession()) {
-            var result = performSearch(version, categories, q, origin, language, highlightCssClass, page, contentSnippets,
-                    contentSnippetsLength, session);
+            var result = performSearch(version, categories, q, origin, language, highlightCssClass, page,
+                    excludeIds, session);
             if (result.total().hitCountLowerBound() > 0) {
                 return new SearchResult<>(result);
             } else {
                 SearchResult.Suggestion suggestion = extractSuggestion(result);
                 if (suggestion != null) {
                     result = performSearch(version, categories, suggestion.query(), origin, language, highlightCssClass, page,
-                            contentSnippets, contentSnippetsLength, session);
+                            excludeIds, session);
                 }
                 return new SearchResult<>(result, result.total().hitCountLowerBound() > 0 ? suggestion : null);
             }
@@ -83,8 +88,8 @@ public class SearchService {
     }
 
     private ElasticsearchSearchResult<GuideSearchHit> performSearch(String version, List<String> categories, String q,
-            String origin, Language language, String highlightCssClass, int page, int contentSnippets,
-            int contentSnippetsLength, SearchSession session) {
+            String origin, Language language, String highlightCssClass, int page,
+            List<String> excludeIds, SearchSession session) {
         return session.search(Guide.class)
                 .extension(ElasticsearchExtension.get())
                 .select(f -> f.composite().from(
@@ -94,42 +99,10 @@ public class SearchService {
                         f.field("origin"),
                         f.highlight(language.addSuffix("title")).highlighter("highlighter_title_or_summary").optional(),
                         f.highlight(language.addSuffix("summary")).highlighter("highlighter_title_or_summary").optional(),
-                        f.highlight(language.addSuffix("fullContent")).highlighter("highlighter_content"))
+                        f.field("categories", String.class).list(),
+                        f.field("subcategories", String.class).list())
                         .asList(GuideSearchHit::new))
-                .where((f, root) -> {
-                    // Match all documents by default
-                    root.add(f.matchAll());
-
-                    if (categories != null && !categories.isEmpty()) {
-                        root.add(f.terms().field("categories").matchingAny(categories));
-                    }
-
-                    if (origin != null && !origin.isEmpty()) {
-                        root.add(f.match().field("origin").matching(origin));
-                    }
-
-                    if (q != null && !q.isBlank()) {
-                        root.add(f.or(
-                                // Duplicate the query so that we apply a multiplicative boost to quarkus.io guides.
-                                // The end result is that a low-relevance match on quarkus.io _can_ be scored
-                                // lower than a high-relevance match on quarkiverse.io,
-                                // if it's significantly more relevant.
-                                // Note that we could, alternatively,
-                                // do something like bool().must(textMatch()).should(origin(quarkusio).boost(2f))),
-                                // but then the boost would be additive, so we would ignore relative relevance
-                                // of quarkus.io/quarkiverse.io results.
-                                f.bool().must(textMatch(f, q, language))
-                                        .filter(originMatch(f, QuarkusIO.QUARKUS_ORIGIN))
-                                        // Always score lower for compatibility (legacy) guides.
-                                        // TODO: Maybe we should use a duplicate query with multiplicative boost for this too?
-                                        .should(f.not(f.match().field(language.addSuffix("topics"))
-                                                .matching("compatibility", ValueModel.INDEX))
-                                                .boost(50.0f))
-                                        .boost(2.0f),
-                                f.bool().must(textMatch(f, q, language))
-                                        .filter(originMatch(f, QuarkiverseIO.QUARKIVERSE_ORIGIN))));
-                    }
-                })
+                .where((f, root) -> buildSearchPredicate(f, root, categories, q, origin, language, excludeIds))
                 .highlighter(f -> f.fastVector()
                         // Highlighters are going to use spans-with-classes so that we will have more control over styling the visual on the search results screen.
                         .tag("<span class=\"" + highlightCssClass + "\">", "</span>"))
@@ -140,22 +113,13 @@ public class SearchService {
                                 .fragmentSize(TITLE_OR_SUMMARY_MAX_SIZE)
                                 // We want the whole text as a single fragment
                                 .numberOfFragments(1))
-                .highlighter(
-                        "highlighter_content", f -> f.fastVector()
-                                // If there's no match in the full content we don't want to return anything.
-                                .noMatchSize(0)
-                                // Content is really huge, so we want to only get small parts of the sentences.
-                                // We give control to the caller on the content snippet length and the number of these fragments
-                                .numberOfFragments(contentSnippets)
-                                .fragmentSize(contentSnippetsLength)
-                                // The rest of fragment configuration is static
-                                .orderByScore(true)
-                                // We don't use sentence boundaries because those can result in huge fragments
-                                .boundaryScanner().chars().boundaryMaxScan(10).end())
                 .sort(f -> f.score().then().field(language.addSuffix("title_sort")))
                 .routing(QuarkusVersionAndLanguageRoutingBinder.searchKeys(version, language))
                 .totalHitCountThreshold(TOTAL_HIT_COUNT_THRESHOLD + (page + 1) * PAGE_SIZE)
-                .requestTransformer(context -> requestSuggestion(context.body(), q, language, highlightCssClass))
+                .requestTransformer(context -> {
+                    wrapWithCategoriesOrderDemotion(context.body());
+                    requestSuggestion(context.body(), q, language, highlightCssClass);
+                })
                 .fetch(page * PAGE_SIZE, PAGE_SIZE);
     }
 
@@ -180,6 +144,247 @@ public class SearchService {
 
     private static MatchPredicateOptionsStep<?> originMatch(SearchPredicateFactory f, String origin) {
         return f.match().field("origin").matching(origin);
+    }
+
+    private void buildSearchPredicate(SearchPredicateFactory f, SimpleBooleanPredicateClausesCollector<?, ?> root,
+            List<String> categories, String q, String origin, Language language, List<String> excludeIds) {
+        root.add(f.matchAll());
+
+        if (categories != null && !categories.isEmpty()) {
+            root.add(f.terms().field("categories").matchingAny(categories));
+        }
+
+        if (origin != null && !origin.isEmpty()) {
+            root.add(f.match().field("origin").matching(origin));
+        }
+
+        if (excludeIds != null && !excludeIds.isEmpty()) {
+            root.add(f.not(f.id().matchingAny(excludeIds, ValueModel.RAW)));
+        }
+
+        if (q != null && !q.isBlank()) {
+            root.add(f.or(
+                    // Duplicate the query so that we apply a multiplicative boost to quarkus.io guides.
+                    // The end result is that a low-relevance match on quarkus.io _can_ be scored
+                    // lower than a high-relevance match on quarkiverse.io,
+                    // if it's significantly more relevant.
+                    // Note that we could, alternatively,
+                    // do something like bool().must(textMatch()).should(origin(quarkusio).boost(2f))),
+                    // but then the boost would be additive, so we would ignore relative relevance
+                    // of quarkus.io/quarkiverse.io results.
+                    f.bool().must(textMatch(f, q, language))
+                            .filter(originMatch(f, QuarkusIO.QUARKUS_ORIGIN))
+                            // Always score lower for compatibility (legacy) guides.
+                            // TODO: Maybe we should use a duplicate query with multiplicative boost for this too?
+                            .should(f.not(f.match().field(language.addSuffix("topics"))
+                                    .matching("compatibility", ValueModel.INDEX))
+                                    .boost(50.0f))
+                            .boost(2.0f),
+                    f.bool().must(textMatch(f, q, language))
+                            .filter(originMatch(f, QuarkiverseIO.QUARKIVERSE_ORIGIN))));
+        }
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Search for Guides grouped by category")
+    @Transactional
+    @Path("/guides/search/grouped")
+    public GroupedSearchResult searchGrouped(@RestQuery @DefaultValue(QuarkusVersions.LATEST) String version,
+            @RestQuery String q,
+            @RestQuery String origin,
+            @RestQuery @DefaultValue("en") Language language,
+            @RestQuery @DefaultValue("highlighted") String highlightCssClass) {
+        try (var session = searchMapping.createSession()) {
+            var esResult = performGroupedSearch(version, q, origin, language, highlightCssClass, session);
+            var result = extractGroupedResults(esResult, language);
+            if (!result.categories().isEmpty()) {
+                return result;
+            } else {
+                SearchResult.Suggestion suggestion = extractSuggestion(esResult);
+                if (suggestion != null) {
+                    esResult = performGroupedSearch(version, suggestion.query(), origin, language, highlightCssClass, session);
+                    result = extractGroupedResults(esResult, language);
+                }
+                return new GroupedSearchResult(result.categories(),
+                        !result.categories().isEmpty() ? suggestion : null);
+            }
+        }
+    }
+
+    private ElasticsearchSearchResult<?> performGroupedSearch(String version, String q, String origin, Language language,
+            String highlightCssClass, SearchSession session) {
+        return session.search(Guide.class)
+                .extension(ElasticsearchExtension.get())
+                .select(f -> f.score())
+                .where((f, root) -> buildSearchPredicate(f, root, null, q, origin, language, null))
+                .routing(QuarkusVersionAndLanguageRoutingBinder.searchKeys(version, language))
+                .requestTransformer(context -> {
+                    wrapWithCategoriesOrderDemotion(context.body());
+                    requestGroupedAggregation(context.body(), language, highlightCssClass);
+                    requestSuggestion(context.body(), q, language, highlightCssClass);
+                })
+                .fetch(0);
+    }
+
+    private void requestGroupedAggregation(JsonObject payload, Language language, String highlightCssClass) {
+        JsonObject aggs = new JsonObject();
+        payload.add("aggs", aggs);
+
+        JsonObject categoriesAgg = new JsonObject();
+        aggs.add("categories", categoriesAgg);
+
+        JsonObject terms = new JsonObject();
+        categoriesAgg.add("terms", terms);
+        terms.addProperty("field", "categories");
+        terms.addProperty("size", GROUPED_CATEGORIES_SIZE);
+        JsonObject order = new JsonObject();
+        order.addProperty("max_score", "desc");
+        terms.add("order", order);
+
+        JsonObject subAggs = new JsonObject();
+        categoriesAgg.add("aggs", subAggs);
+
+        JsonObject maxScore = new JsonObject();
+        subAggs.add("max_score", maxScore);
+        JsonObject max = new JsonObject();
+        maxScore.add("max", max);
+        JsonObject script = new JsonObject();
+        script.addProperty("source", "_score");
+        max.add("script", script);
+
+        JsonObject documents = new JsonObject();
+        subAggs.add("documents", documents);
+        JsonObject topHits = new JsonObject();
+        documents.add("top_hits", topHits);
+        topHits.addProperty("size", GROUPED_DOCS_PER_CATEGORY);
+
+        JsonArray sort = new JsonArray();
+        topHits.add("sort", sort);
+        JsonObject scoreSort = new JsonObject();
+        JsonObject scoreSortOrder = new JsonObject();
+        scoreSortOrder.addProperty("order", "desc");
+        scoreSort.add("_score", scoreSortOrder);
+        sort.add(scoreSort);
+        JsonObject titleSort = new JsonObject();
+        JsonObject titleSortOptions = new JsonObject();
+        titleSortOptions.addProperty("order", "asc");
+        titleSortOptions.addProperty("unmapped_type", "keyword");
+        titleSort.add(language.addSuffix("title_sort"), titleSortOptions);
+        sort.add(titleSort);
+
+        JsonArray sourceFields = new JsonArray();
+        sourceFields.add("type");
+        sourceFields.add("status");
+        sourceFields.add("origin");
+        sourceFields.add(language.addSuffix("title"));
+        sourceFields.add(language.addSuffix("summary"));
+        topHits.add("_source", sourceFields);
+
+        JsonObject highlight = new JsonObject();
+        topHits.add("highlight", highlight);
+        highlight.add("pre_tags", jsonArray("<span class=\"" + highlightCssClass + "\">"));
+        highlight.add("post_tags", jsonArray("</span>"));
+        JsonObject highlightFields = new JsonObject();
+        highlight.add("fields", highlightFields);
+        for (String field : List.of(language.addSuffix("title"), language.addSuffix("summary"))) {
+            JsonObject fieldConfig = new JsonObject();
+            fieldConfig.addProperty("type", "fvh");
+            fieldConfig.addProperty("no_match_size", TITLE_OR_SUMMARY_MAX_SIZE);
+            fieldConfig.addProperty("fragment_size", TITLE_OR_SUMMARY_MAX_SIZE);
+            fieldConfig.addProperty("number_of_fragments", 1);
+            highlightFields.add(field, fieldConfig);
+        }
+    }
+
+    private static JsonArray jsonArray(String... values) {
+        JsonArray array = new JsonArray();
+        for (String value : values) {
+            array.add(value);
+        }
+        return array;
+    }
+
+    private GroupedSearchResult extractGroupedResults(ElasticsearchSearchResult<?> result, Language language) {
+        String titleField = language.addSuffix("title");
+        String summaryField = language.addSuffix("summary");
+
+        List<CategoryGroup> categories = new ArrayList<>();
+
+        JsonObject aggregations = result.responseBody().getAsJsonObject("aggregations");
+        if (aggregations == null) {
+            return new GroupedSearchResult(categories);
+        }
+        JsonArray buckets = aggregations.getAsJsonObject("categories").getAsJsonArray("buckets");
+
+        for (var bucketElement : buckets) {
+            JsonObject bucket = bucketElement.getAsJsonObject();
+            String category = bucket.get("key").getAsString();
+            long docCount = bucket.get("doc_count").getAsLong();
+
+            JsonArray topHits = bucket.getAsJsonObject("documents")
+                    .getAsJsonObject("hits").getAsJsonArray("hits");
+
+            List<GroupedGuideHit> hits = new ArrayList<>();
+            for (var hitElement : topHits) {
+                JsonObject hit = hitElement.getAsJsonObject();
+                URI url = URI.create(hit.get("_id").getAsString());
+                JsonObject source = hit.getAsJsonObject("_source");
+                JsonObject highlightObj = hit.getAsJsonObject("highlight");
+
+                hits.add(new GroupedGuideHit(
+                        url,
+                        getStringOrNull(source, "type"),
+                        getStringOrNull(source, "status"),
+                        getStringOrNull(source, "origin"),
+                        getHighlightedOrSource(highlightObj, source, titleField),
+                        getHighlightedOrSource(highlightObj, source, summaryField)));
+            }
+            categories.add(new CategoryGroup(category, docCount, hits));
+        }
+        return new GroupedSearchResult(categories);
+    }
+
+    private static String getHighlightedOrSource(JsonObject highlight, JsonObject source, String field) {
+        if (highlight != null) {
+            JsonArray fragments = highlight.getAsJsonArray(field);
+            if (fragments != null && !fragments.isEmpty()) {
+                return fragments.get(0).getAsString();
+            }
+        }
+        return getStringOrNull(source, field);
+    }
+
+    private static String getStringOrNull(JsonObject obj, String field) {
+        var element = obj.get(field);
+        return element != null && !element.isJsonNull() ? element.getAsString() : null;
+    }
+
+    private static void wrapWithCategoriesOrderDemotion(JsonObject payload) {
+        JsonObject originalQuery = payload.getAsJsonObject("query");
+        if (originalQuery == null) {
+            return;
+        }
+
+        JsonObject functionScore = new JsonObject();
+        functionScore.add("query", originalQuery);
+
+        JsonObject fieldValueFactor = new JsonObject();
+        fieldValueFactor.addProperty("field", "categoriesOrderDemotion");
+        fieldValueFactor.addProperty("modifier", "none");
+        fieldValueFactor.addProperty("missing", Guide.NO_CATEGORY_ORDER_DEMOTION);
+
+        JsonArray functions = new JsonArray();
+        JsonObject function = new JsonObject();
+        function.add("field_value_factor", fieldValueFactor);
+        functions.add(function);
+        functionScore.add("functions", functions);
+
+        functionScore.addProperty("boost_mode", "multiply");
+
+        JsonObject wrapper = new JsonObject();
+        wrapper.add("function_score", functionScore);
+        payload.add("query", wrapper);
     }
 
     private void requestSuggestion(JsonObject payload, String q, Language language, String highlightCssClass) {
@@ -218,7 +423,7 @@ public class SearchService {
             }
         } catch (RuntimeException e) {
             // Though it shouldn't happen, just in case we will catch any exceptions and return no suggestions:
-            Log.warnf(e, "Failed to extract suggestion: %s" + e.getMessage());
+            Log.warnf(e, "Failed to extract suggestion: %s", e.getMessage());
         }
         return null;
     }

--- a/src/main/java/io/quarkus/search/app/dto/GroupedGuideHit.java
+++ b/src/main/java/io/quarkus/search/app/dto/GroupedGuideHit.java
@@ -1,0 +1,6 @@
+package io.quarkus.search.app.dto;
+
+import java.net.URI;
+
+public record GroupedGuideHit(URI url, String type, String status, String origin, String title, String summary) {
+}

--- a/src/main/java/io/quarkus/search/app/dto/GroupedSearchResult.java
+++ b/src/main/java/io/quarkus/search/app/dto/GroupedSearchResult.java
@@ -1,0 +1,14 @@
+package io.quarkus.search.app.dto;
+
+import java.util.List;
+
+public record GroupedSearchResult(List<CategoryGroup> categories, SearchResult.Suggestion suggestion) {
+
+    public GroupedSearchResult(List<CategoryGroup> categories) {
+        this(categories, null);
+    }
+
+    public record CategoryGroup(String category, long hitCount, List<GroupedGuideHit> hits) {
+    }
+
+}

--- a/src/main/java/io/quarkus/search/app/dto/GuideSearchHit.java
+++ b/src/main/java/io/quarkus/search/app/dto/GuideSearchHit.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public record GuideSearchHit(URI url, String type, String status, String origin, String title, String summary,
-        Set<String> content) {
+        Set<String> categories, Set<String> subcategories) {
 
     public GuideSearchHit(URI url,
             String type,
@@ -15,8 +15,11 @@ public record GuideSearchHit(URI url, String type, String status, String origin,
             String origin,
             Optional<String> title,
             Optional<String> summary,
-            List<String> content) {
-        this(url, type, status, origin, title.orElse(""), summary.orElse(""), wrap(content));
+            List<String> categories,
+            List<String> subcategories) {
+        this(url, type, status, origin, title.orElse(""), summary.orElse(""),
+                categories == null ? Set.of() : new LinkedHashSet<>(categories),
+                subcategories == null ? Set.of() : new LinkedHashSet<>(subcategories));
     }
 
     @SuppressWarnings("unchecked")
@@ -24,15 +27,8 @@ public record GuideSearchHit(URI url, String type, String status, String origin,
         this(
                 (URI) values.get(0), (String) values.get(1), (String) values.get(2), (String) values.get(3),
                 (Optional<String>) values.get(4), (Optional<String>) values.get(5),
-                (List<String>) values.get(6));
-    }
-
-    private static Set<String> wrap(List<String> strings) {
-        Set<String> set = new LinkedHashSet<>();
-        for (String string : strings) {
-            set.add("…%s…".formatted(string));
-        }
-        return set;
+                (List<String>) values.get(6),
+                (List<String>) values.get(7));
     }
 
 }

--- a/src/main/java/io/quarkus/search/app/entity/Guide.java
+++ b/src/main/java/io/quarkus/search/app/entity/Guide.java
@@ -1,6 +1,7 @@
 package io.quarkus.search.app.entity;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -23,6 +24,7 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderR
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.loading.mapping.annotation.EntityLoadingBinderRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
@@ -62,14 +64,34 @@ public class Guide {
     @I18nFullTextField(name = "keywords_autocomplete", analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     public I18nData<String> keywords = new I18nData<>();
 
-    @I18nFullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), highlightable = Highlightable.FAST_VECTOR, termVector = TermVector.WITH_POSITIONS_OFFSETS, analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
+    @I18nFullTextField(name = "fullContent", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nFullTextField(name = "fullContent_autocomplete", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzerPrefix = AnalysisConfigurer.AUTOCOMPLETE, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nFullTextField(name = "fullContent_suggestion", valueBridge = @ValueBridgeRef(type = InputProviderHtmlBodyTextBridge.class), analyzerPrefix = AnalysisConfigurer.SUGGESTION, searchAnalyzerPrefix = AnalysisConfigurer.SUGGESTION)
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
     public I18nData<InputProvider> htmlFullContentProvider = new I18nData<>();
 
-    @KeywordField(name = "categories", aggregable = Aggregable.YES)
+    @KeywordField(name = "categories", aggregable = Aggregable.YES, projectable = Projectable.YES)
     public Set<String> categories = Set.of();
+
+    @KeywordField(name = "subcategories", aggregable = Aggregable.YES, projectable = Projectable.YES)
+    public Set<String> subcategories = Set.of();
+
+    public List<Integer> categoriesOrder = List.of();
+
+    // Demotion factor derived from the guide's best (lowest) position across all categories in the
+    // managed YAML. Guides listed first are considered more important.
+    // Range is (0, 1]: ordinal 0 -> 1.0 (no demotion), higher ordinals (positioned later within the category) -> approaching 0.
+    // Used as a field_value_factor with boost_mode "multiply" so it scales the query relevance
+    // score down for guides listed later, without ever amplifying above the base score.
+    public static final double NO_CATEGORY_ORDER_DEMOTION = 0.001;
+
+    @GenericField(name = "categoriesOrderDemotion", searchable = Searchable.NO, sortable = Sortable.YES)
+    public double getCategoriesOrderDemotion() {
+        if (categoriesOrder.isEmpty()) {
+            return NO_CATEGORY_ORDER_DEMOTION;
+        }
+        return 1.0 / (1.0 + 0.2 * Collections.min(categoriesOrder));
+    }
 
     @I18nFullTextField(name = "topics", analyzerPrefix = AnalysisConfigurer.DEFAULT, searchAnalyzerPrefix = AnalysisConfigurer.DEFAULT_SEARCH)
     @I18nKeywordField(name = "topics_faceting", searchable = Searchable.YES, projectable = Projectable.YES, aggregable = Aggregable.YES)

--- a/src/main/java/io/quarkus/search/app/hibernate/InputProvider.java
+++ b/src/main/java/io/quarkus/search/app/hibernate/InputProvider.java
@@ -27,7 +27,7 @@ public record InputProvider(Path content) {
         String writableContent = null;
         if (content != null) {
             // Remove meaningless/duplicate content
-            content.select(".toc, .tocwrapper, .relations")
+            content.select(".toc, .tocwrapper, .relations, .guide-nav-wrapper, .guide-metadata-bar")
                     .remove();
             writableContent = encode(content);
         } else {

--- a/src/main/java/io/quarkus/search/app/quarkiverseio/QuarkiverseIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkiverseio/QuarkiverseIO.java
@@ -12,9 +12,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.quarkus.search.app.SearchService;
 import io.quarkus.search.app.entity.Guide;
 import io.quarkus.search.app.hibernate.InputProvider;
 import io.quarkus.search.app.indexing.reporting.FailureCollector;
@@ -35,6 +37,10 @@ public class QuarkiverseIO implements Closeable {
     private static final List<String> LATEST_VERSIONS = List.of("dev", "main");
 
     public static final String QUARKIVERSE_ORIGIN = "quarkiverse-hub";
+    public static final String QUARKIVERSE_CATEGORY = "Quarkiverse";
+    // we are somewhat demoting the Quarkiverse to the "Second page" of the search results
+    // by positioning them after the first articles from the "main categories"
+    private static final int INITIAL_DEPTH = SearchService.GROUPED_DOCS_PER_CATEGORY / 2;
 
     private final FailureCollector failureCollector;
 
@@ -50,11 +56,13 @@ public class QuarkiverseIO implements Closeable {
         this.tempDir = tempDir;
     }
 
-    private Guide readGuide(Path file) {
+    private Guide readGuide(Path file, int ordinal) {
         Guide guide = new Guide();
         guide.url = baseUri.resolve(pages.get().relativize(file).toString());
         guide.type = "reference";
         guide.origin = QUARKIVERSE_ORIGIN;
+        guide.categories = Set.of(QUARKIVERSE_CATEGORY);
+        guide.categoriesOrder = List.of(ordinal);
 
         try {
             Document document = Jsoup.parse(file);
@@ -94,8 +102,7 @@ public class QuarkiverseIO implements Closeable {
                     // if we don't find one, we'll report it as a "warning"
                     .map(this::latestVersion)
                     .filter(Objects::nonNull)
-                    .flatMap(this::filesToIndex)
-                    .map(this::readGuide);
+                    .flatMap(this::readGuides);
         } catch (IOException e) {
             if (quarkiverseStream != null) {
                 quarkiverseStream.close();
@@ -106,15 +113,16 @@ public class QuarkiverseIO implements Closeable {
         }
     }
 
-    private Stream<Path> filesToIndex(Path path) {
-        List<Path> files = new ArrayList<>();
+    private Stream<Guide> readGuides(Path extensionDir) {
+        List<Guide> guides = new ArrayList<>();
         try {
             Files.walkFileTree(
-                    path, new SimpleFileVisitor<>() {
+                    extensionDir, new SimpleFileVisitor<>() {
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                             if (file.getFileName().toString().endsWith(".html")) {
-                                files.add(file);
+                                int depth = INITIAL_DEPTH + extensionDir.relativize(file).getNameCount() - 1;
+                                guides.add(readGuide(file, depth));
                             }
                             return FileVisitResult.CONTINUE;
                         }
@@ -130,9 +138,10 @@ public class QuarkiverseIO implements Closeable {
                         }
                     });
         } catch (IOException e) {
-            failureCollector.critical(FailureCollector.Stage.PARSING, "Failed to traverse the directory tree: " + path, e);
+            failureCollector.critical(FailureCollector.Stage.PARSING,
+                    "Failed to traverse the directory tree: " + extensionDir, e);
         }
-        return files.stream();
+        return guides.stream();
     }
 
     private Path latestVersion(Path extensionRoot) {

--- a/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
+++ b/src/main/java/io/quarkus/search/app/quarkusio/QuarkusIO.java
@@ -12,6 +12,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -81,6 +82,10 @@ public class QuarkusIO implements Closeable {
 
     public static Path yamlMetadataPath(String version) {
         return Path.of("_data", "versioned", version.replace('.', '-'), "index", "quarkus.yaml");
+    }
+
+    public static Path yamlCategoriesMetadataPath(String version) {
+        return Path.of("_data", "versioned", version.replace('.', '-'), "index", "categories.yaml");
     }
 
     public static Path yamlVersionMetadataPath() {
@@ -176,14 +181,19 @@ public class QuarkusIO implements Closeable {
                             .map(QuarkusIO::extractVersion)
                             .filter(versionFilter)
                             .flatMap(quarkusVersion -> {
-                                String quarkus = quarkusVersion.path();
+                                Stream<Guide> fromCategories = tryParseCategoriesYaml(
+                                        cloneDirectory, quarkusVersion, language,
+                                        repository, translationSourcesTree);
+                                if (fromCategories != null) {
+                                    return fromCategories;
+                                }
 
                                 Catalog translations = translations(
                                         repository, translationSourcesTree,
                                         resolveTranslationPath(
                                                 quarkusVersion.versionDirectory(), "quarkus.yaml", language));
 
-                                try (InputStream file = cloneDirectory.sourcesFile(quarkus)) {
+                                try (InputStream file = cloneDirectory.sourcesFile(quarkusVersion.path())) {
                                     return parseYamlMetadata(cloneDirectory, file, quarkusVersion.version(), language,
                                             translations);
                                 } catch (IOException e) {
@@ -193,6 +203,25 @@ public class QuarkusIO implements Closeable {
                                 }
                             });
                 });
+    }
+
+    private Stream<Guide> tryParseCategoriesYaml(GitCloneDirectory cloneDirectory,
+            VersionAndPaths quarkusVersion, Language language,
+            Repository repository, RevTree translationSourcesTree) {
+        String categoriesPath = yamlCategoriesMetadataPath(quarkusVersion.version()).toString();
+        try (InputStream file = cloneDirectory.sourcesFile(categoriesPath)) {
+            Catalog translations = translations(
+                    repository, translationSourcesTree,
+                    resolveTranslationPath(
+                            quarkusVersion.versionDirectory(), "categories.yaml", language));
+
+            return parseCategoriesYamlMetadata(cloneDirectory, file, quarkusVersion.version(), language, translations);
+        } catch (NoSuchFileException e) {
+            return null;
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Unable to load %s: %s".formatted(categoriesPath, e.getMessage()), e);
+        }
     }
 
     // older version guides like guides-2-7.yaml or guides-2-13.yaml
@@ -282,6 +311,91 @@ public class QuarkusIO implements Closeable {
 
             return parsed.stream();
         });
+    }
+
+    @SuppressWarnings("unchecked")
+    private Stream<Guide> parseCategoriesYamlMetadata(GitCloneDirectory cloneDirectory, InputStream categoriesYamlStream,
+            String quarkusVersion, Language language, Catalog messages) {
+        return parse(categoriesYamlStream, yaml -> {
+            Map<URI, Guide> parsed = new HashMap<>();
+
+            List<Map<String, Object>> categories = (List<Map<String, Object>>) yaml.get("categories");
+            if (categories == null) {
+                return Stream.empty();
+            }
+
+            for (Map<String, Object> categoryObj : categories) {
+                String categoryId = toString(categoryObj.get("id"));
+                int categoryOrdinal = 0;
+
+                List<Map<String, Object>> directGuides = (List<Map<String, Object>>) categoryObj.get("guides");
+                if (directGuides != null) {
+                    for (Map<String, Object> parsedGuide : directGuides) {
+                        mergeGuide(cloneDirectory, quarkusVersion, language, messages,
+                                parsed, parsedGuide, categoryId, null, categoryOrdinal++);
+                    }
+                }
+
+                List<Map<String, Object>> subcategories = (List<Map<String, Object>>) categoryObj.get("subcategories");
+                if (subcategories != null) {
+                    for (Map<String, Object> subcategoryObj : subcategories) {
+                        String subcategoryId = toString(subcategoryObj.get("id"));
+                        List<Map<String, Object>> subGuides = (List<Map<String, Object>>) subcategoryObj.get("guides");
+                        if (subGuides != null) {
+                            for (Map<String, Object> parsedGuide : subGuides) {
+                                mergeGuide(cloneDirectory, quarkusVersion, language, messages,
+                                        parsed, parsedGuide, categoryId, subcategoryId, categoryOrdinal++);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return parsed.values().stream();
+        });
+    }
+
+    private void mergeGuide(GitCloneDirectory cloneDirectory, String quarkusVersion,
+            Language language, Catalog messages,
+            Map<URI, Guide> parsed, Map<String, Object> parsedGuide,
+            String categoryId, String subcategoryId, int ordinal) {
+        String parsedUrl = toString(parsedGuide.get("url"));
+        if (parsedUrl == null || parsedUrl.startsWith("http")) {
+            return;
+        }
+
+        URI guideUrl = httpUrl(siteUris.get(language), quarkusVersion, parsedUrl);
+        Guide existing = parsed.get(guideUrl);
+
+        if (existing != null) {
+            existing.categories.add(categoryId);
+            if (subcategoryId != null) {
+                existing.subcategories.add(subcategoryId);
+            }
+            existing.categoriesOrder.add(ordinal);
+            return;
+        }
+
+        Guide guide = createGuide(cloneDirectory, quarkusVersion, toString(parsedGuide.get("type")), parsedGuide,
+                "summary", language, messages);
+        if (guide == null) {
+            return;
+        }
+        guide.categories = new HashSet<>();
+        guide.categories.add(categoryId);
+        guide.subcategories = new HashSet<>();
+        if (subcategoryId != null) {
+            guide.subcategories.add(subcategoryId);
+        }
+        guide.categoriesOrder = new ArrayList<>();
+        guide.categoriesOrder.add(ordinal);
+        guide.keywords.set(language, translate(messages, toString(parsedGuide.get("keywords"))));
+        guide.topics = toSet(parsedGuide.get("topics")).stream()
+                .map(v -> new I18nData<>(language, v))
+                .collect(Collectors.toList());
+        guide.extensions = toSet(parsedGuide.get("extensions"));
+
+        parsed.put(guideUrl, guide);
     }
 
     private Stream<Guide> parseYamlLegacyMetadata(GitCloneDirectory cloneDirectory, InputStream quarkusYamlPath, String version,

--- a/src/main/resources/web/app/qs-categories-toc.ts
+++ b/src/main/resources/web/app/qs-categories-toc.ts
@@ -1,0 +1,202 @@
+import {LitElement, html, css} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
+import {QS_GROUPED_RESULT_EVENT, QS_RESULT_EVENT, QS_START_EVENT, QsGroupedResult} from './qs-form';
+
+export interface TocCategory {
+  id: string;
+  title: string;
+  subcategories?: TocCategory[];
+}
+
+@customElement('qs-categories-toc')
+export class QsCategoriesToc extends LitElement {
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    h3 {
+      margin: 0 0 0.4rem 0;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-color, black);
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .toc > ul > li {
+      display: block;
+      margin-bottom: 0.35rem;
+      padding: 0;
+    }
+
+    .toc > ul > li > a {
+      display: block;
+      padding: 0.15rem 0.4rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      line-height: 1.5;
+      color: var(--text-color, black);
+      text-decoration: none;
+      border-radius: 3px;
+      cursor: pointer;
+    }
+
+    .toc > ul > li > a:hover {
+      background-color: var(--hover-background-color, rgba(0, 0, 0, 0.05));
+      color: var(--link-color, #1259A5);
+    }
+
+    /* Subcategory chips */
+    .toc > ul > li > ul {
+      padding: 0.1rem 0 0.2rem 0.6rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+    }
+
+    .toc > ul > li > ul > li {
+      display: inline;
+      line-height: 1;
+    }
+
+    .toc > ul > li > ul > li > a {
+      display: inline-block;
+      padding: 0.1rem 0.45rem;
+      font-size: 0.7rem;
+      line-height: 1.5;
+      color: var(--text-color, black);
+      opacity: 0.75;
+      text-decoration: none;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+
+    .toc > ul > li > ul > li > a:hover {
+      opacity: 1;
+      color: var(--link-hover-color, white);
+      background-color: var(--link-color, #1259A5);
+    }
+
+    .count {
+      font-weight: 400;
+      font-size: 0.75rem;
+      opacity: 0.7;
+    }
+  `;
+
+  @property({type: Array}) categories: TocCategory[] = [];
+  @property({type: Object, attribute: 'categories-meta'}) categoriesMeta: Record<string, { title: string, description?: string }> = {};
+
+  @state() private _groupedResult: QsGroupedResult | undefined;
+
+  private _form: HTMLElement;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._form = document.querySelector('qs-form');
+    if (this._form) {
+      this._form.addEventListener(QS_GROUPED_RESULT_EVENT, this._handleGroupedResult);
+      this._form.addEventListener(QS_RESULT_EVENT, this._handleResult);
+      this._form.addEventListener(QS_START_EVENT, this._loadingStart);
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._form) {
+      this._form.removeEventListener(QS_GROUPED_RESULT_EVENT, this._handleGroupedResult);
+      this._form.removeEventListener(QS_RESULT_EVENT, this._handleResult);
+      this._form.removeEventListener(QS_START_EVENT, this._loadingStart);
+    }
+    super.disconnectedCallback();
+  }
+
+  private get _isSearchMode(): boolean {
+    return !!(this._groupedResult?.categories?.length);
+  }
+
+  render() {
+    if (this._isSearchMode) {
+      return this._renderSearchToc();
+    }
+    if (this.categories && this.categories.length > 0) {
+      return this._renderBrowseToc();
+    }
+    return html`<slot></slot>`;
+  }
+
+  private _renderBrowseToc() {
+    return html`
+      <div class="toc">
+        <h3>Categories</h3>
+        <ul>
+          ${this.categories.map(cat => html`
+            <li>
+              <a @click=${(e: Event) => this._scrollToCategory(e, cat.id)}>${cat.title}</a>
+              ${cat.subcategories && cat.subcategories.length > 0 ? html`
+                <ul>
+                  ${cat.subcategories.map(sub => html`
+                    <li><a @click=${(e: Event) => this._scrollToCategory(e, sub.id)}>${sub.title}</a></li>
+                  `)}
+                </ul>
+              ` : ''}
+            </li>
+          `)}
+        </ul>
+      </div>
+    `;
+  }
+
+  private _renderSearchToc() {
+    return html`
+      <div class="toc">
+        <h3>Categories</h3>
+        <ul>
+          ${this._groupedResult.categories.map(cat => {
+            const meta = this.categoriesMeta?.[cat.category] || {};
+            const title = meta.title || cat.category;
+            return html`
+              <li>
+                <a @click=${(e: Event) => this._scrollToCategory(e, cat.category)}>
+                  ${title} <span class="count">(${cat.hitCount})</span>
+                </a>
+              </li>
+            `;
+          })}
+        </ul>
+      </div>
+    `;
+  }
+
+  private _scrollToCategory(e: Event, category: string) {
+    e.preventDefault();
+    const target = document.querySelector('qs-target');
+    if (target?.shadowRoot) {
+      let group = target.shadowRoot.querySelector(`qs-guide-group[category="${CSS.escape(category)}"]`);
+      if (!group) {
+        group = target.querySelector(`qs-guide-group[category="${CSS.escape(category)}"]`);
+      }
+      if(group) {
+        group.scrollIntoView({behavior: 'smooth', block: 'start'});
+      }
+    }
+  }
+
+  private _handleGroupedResult = (e: CustomEvent) => {
+    this._groupedResult = e.detail;
+  }
+
+  private _handleResult = (e: CustomEvent) => {
+    this._groupedResult = undefined;
+  }
+
+  private _loadingStart = () => {
+    // TODO: maybe add loader later ?
+  }
+}

--- a/src/main/resources/web/app/qs-form.ts
+++ b/src/main/resources/web/app/qs-form.ts
@@ -5,6 +5,7 @@ import {LocalSearch} from "./local-search";
 
 export const QS_START_EVENT = 'qs-start';
 export const QS_RESULT_EVENT = 'qs-result';
+export const QS_GROUPED_RESULT_EVENT = 'qs-grouped-result';
 export const QS_NEXT_PAGE_EVENT = 'qs-next-page';
 export const QS_QUERY_SUGGESTION_EVENT = 'qs-query-suggestion';
 
@@ -28,6 +29,19 @@ export interface QsSuggestion {
   highlighted: string;
 }
 
+export interface QsCategoryGroup {
+  category: string;
+  hitCount: number;
+  hits: QsHit[];
+}
+
+export interface QsGroupedResult {
+  categories: QsCategoryGroup[];
+  suggestion?: QsSuggestion;
+  search: any;
+  server: string;
+}
+
 /**
  * This component is the form that triggers the search
  */
@@ -36,11 +50,11 @@ export class QsForm extends LitElement {
 
   static styles = css`
 
-      ::slotted(*) {
-          display: block !important;
+      #qs-form {
+          display: contents;
       }
 
-      .quarkus-search {
+      ::slotted(section) {
           display: block !important;
       }
 
@@ -57,6 +71,7 @@ export class QsForm extends LitElement {
   @property({type: String, attribute: 'quarkus-version'}) quarkusversion?: string;
   @property({type: String, attribute: 'local-search'}) localSearch: boolean = false;
   @property({type: String, attribute: 'origin-filter'}) originFilter: string = '';
+  @property({type: Boolean}) grouped: boolean = false;
 
   @state({
     hasChanged(newVal: any, oldVal: any) {
@@ -99,7 +114,7 @@ export class QsForm extends LitElement {
       this._initialQueryStringPresent = false;
       this._handleInputChange(null);
     }
-    window.location.hash = this._browserData ? (new URLSearchParams(this._browserData)).toString() : window.location.hash;
+    this._updateHash();
     if (!this._backendData) {
       this._clearSearch();
     } else {
@@ -158,32 +173,49 @@ export class QsForm extends LitElement {
       return;
     }
 
-    this._jsonFetch(controller, 'GET', this._backendData, this._page > 0 ? this.initialTimeout : this.moreTimeout)
-      .then((r: any) => {
-        if (this._page > 0) {
-          this._currentHitCount += r.hits.length;
-        } else {
-          this._currentHitCount = r.hits.length;
+    if (this.grouped) {
+      this._groupedFetch(controller)
+        .then((r: any) => {
+          this.dispatchEvent(new CustomEvent(QS_GROUPED_RESULT_EVENT, {detail: {...r, search: this._backendData, server: this.server}}));
+        }).catch(e => {
+          console.error('Could not run grouped search: ' + e);
+          if (this._abortController != controller) {
+            return;
+          }
+          this._localSearch();
+        }).finally(() => {
+          if (this._abortController == controller) {
+            this._abortController = null
+          }
+        });
+    } else {
+      this._jsonFetch(controller, 'GET', this._backendData, this._page > 0 ? this.initialTimeout : this.moreTimeout)
+        .then((r: any) => {
+          if (this._page > 0) {
+            this._currentHitCount += r.hits.length;
+          } else {
+            this._currentHitCount = r.hits.length;
+          }
+          const total = r.total?.lowerBound;
+          const hasMoreHits = r.hits.length > 0 && total > this._currentHitCount;
+          this.dispatchEvent(new CustomEvent(QS_RESULT_EVENT, {detail: {...r, search: this._backendData, page: this._page, hasMoreHits}}));
+        }).catch(e => {
+        console.error('Could not run search: ' + e);
+        if (this._abortController != controller) {
+          // A concurrent search erased ours; most likely input changed while waiting for results.
+          // Ignore this search and let the concurrent one reset the data as it sees fit.
+          return;
         }
-        const total = r.total?.lowerBound;
-        const hasMoreHits = r.hits.length > 0 && total > this._currentHitCount;
-        this.dispatchEvent(new CustomEvent(QS_RESULT_EVENT, {detail: {...r, search: this._backendData, page: this._page, hasMoreHits}}));
-      }).catch(e => {
-      console.error('Could not run search: ' + e);
-      if (this._abortController != controller) {
-        // A concurrent search erased ours; most likely input changed while waiting for results.
-        // Ignore this search and let the concurrent one reset the data as it sees fit.
-        return;
-      }
-      this._page = 0;
-      this._currentHitCount = 0;
-      // Fall back to Javascript in-page search
-      this._localSearch();
-    }).finally(() => {
-      if (this._abortController == controller) {
-        this._abortController = null
-      }
-    });
+        this._page = 0;
+        this._currentHitCount = 0;
+        // Fall back to Javascript in-page search
+        this._localSearch();
+      }).finally(() => {
+        if (this._abortController == controller) {
+          this._abortController = null
+        }
+      });
+    }
   }
 
   private _searchDebounced = debounce(this._search, 300);
@@ -192,8 +224,6 @@ export class QsForm extends LitElement {
     const formElements = this._getFormElements();
     const formData = {
       language: this.language,
-      contentSnippets: 2,
-      contentSnippetsLength: 120,
     };
     const queryData = {};
     if (this.quarkusversion) {
@@ -242,6 +272,48 @@ export class QsForm extends LitElement {
     return el.tagName.toLowerCase() === 'input'
   }
 
+  private _updateHash() {
+    const hashParams = new URLSearchParams(window.location.hash.substring(1));
+    const formKeys = new Set<string>();
+    this._getFormElements().forEach(el => formKeys.add(el.name));
+    formKeys.forEach(key => hashParams.delete(key));
+    if (this._browserData) {
+      for (const [key, value] of Object.entries(this._browserData)) {
+        hashParams.set(key, value as string);
+      }
+    }
+    const newHash = hashParams.toString();
+    window.location.hash = newHash ? newHash : '';
+  }
+
+  private async _groupedFetch(controller: AbortController) {
+    const queryParams: Record<string, string> = {};
+    if (this._backendData['q']) {
+      queryParams['q'] = this._backendData['q'];
+    }
+    if (this._backendData['language']) {
+      queryParams['language'] = this._backendData['language'];
+    }
+    if (this._backendData['version']) {
+      queryParams['version'] = this._backendData['version'];
+    }
+    if (this._backendData['origin']) {
+      queryParams['origin'] = this._backendData['origin'];
+    }
+    const timeoutId = setTimeout(() => controller.abort(), this.initialTimeout);
+    const response = await fetch(this.server + '/api/guides/search/grouped?' + (new URLSearchParams(queryParams)).toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      body: null
+    });
+    clearTimeout(timeoutId);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw 'Response status is ' + response.status + '; response: ' + await response.text();
+    }
+  }
+
   private async _jsonFetch(controller: AbortController, method: string, params: object, timeout: number) {
     const queryParams: Record<string, string> = {
       ...params,
@@ -268,7 +340,11 @@ export class QsForm extends LitElement {
       this._abortController.abort();
       this._abortController = null;
     }
-    this.dispatchEvent(new CustomEvent(QS_RESULT_EVENT));
+    if (this.grouped) {
+      this.dispatchEvent(new CustomEvent(QS_GROUPED_RESULT_EVENT));
+    } else {
+      this.dispatchEvent(new CustomEvent(QS_RESULT_EVENT));
+    }
   }
 
   private _localSearch(): any {

--- a/src/main/resources/web/app/qs-guide-group.ts
+++ b/src/main/resources/web/app/qs-guide-group.ts
@@ -1,0 +1,283 @@
+import {LitElement, html, css, unsafeCSS, PropertyValues} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
+import './qs-guide';
+import icons from './assets/icons';
+
+export interface SearchContext {
+  server: string;
+  query: string;
+  language: string;
+  version?: string;
+}
+
+@customElement('qs-guide-group')
+export class QsGuideGroup extends LitElement {
+
+  static styles = css`
+    .qs-guide-group {
+      margin-bottom: 2rem;
+    }
+
+    .qs-guide-group-header {
+      display: flex;
+      align-items: center;
+      margin-bottom: 0.25rem;
+    }
+
+    .qs-guide-group-header h2,
+    .qs-guide-group-header h3 {
+      margin: 0;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .qs-guide-group-header h2 {
+      font-size: 1.3rem;
+    }
+
+    .qs-guide-group-header h3 {
+      font-size: 1.05rem;
+    }
+
+    .count {
+      margin-left: 0.5rem;
+      font-size: 0.85rem;
+      color: var(--content-highlight-color, #777);
+      white-space: nowrap;
+    }
+
+    .title-line {
+      background-color: var(--card-border-color, #e2e6ec);
+      flex: 1;
+      height: 1px;
+      margin-left: 10px;
+    }
+
+    .qs-guide-group-description {
+      margin: 0 0 0.5rem 0;
+      color: var(--content-highlight-color, #777);
+      opacity: 0.7;
+      font-size: 0.85rem;
+    }
+
+    .qs-guide-group-content {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      grid-gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .qs-guide-group-content qs-guide {
+      grid-column: span 4;
+    }
+
+    @media screen and (max-width: 1300px) {
+      .qs-guide-group-content qs-guide {
+        grid-column: span 6;
+      }
+    }
+
+    @media screen and (max-width: 768px) {
+      .qs-guide-group-content qs-guide {
+        grid-column: span 12;
+      }
+    }
+
+    .qs-guide-group-more {
+      text-align: end;
+      padding: 0.5rem 0 1rem 0;
+    }
+
+    .qs-guide-group-more button {
+      background: none;
+      border: none;
+      border-radius: 0.5rem;
+      padding: 0.5rem 1.5rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: var(--main-text-color, black);
+      transition: background-color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .qs-guide-group-more button:hover {
+      border-color: var(--card-border-hover-color, var(--link-color, #1259A5));
+      background-color: var(--tag-chip-bg, #eef2f8);
+    }
+
+    .qs-guide-group-more button:disabled {
+      opacity: 0.6;
+      cursor: wait;
+    }
+
+    .chevron {
+      display: inline-block;
+      margin-left: 0.5rem;
+      font-size: 0.7rem;
+    }
+
+    .loading-spinner {
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+      background-image: url('${unsafeCSS(icons.loading)}');
+      background-repeat: no-repeat;
+      background-size: contain;
+      vertical-align: middle;
+      margin-left: 0.5rem;
+    }
+  `;
+
+  @property({type: String}) category: string = '';
+  @property({type: String}) title: string = '';
+  @property({type: String}) description: string = '';
+  @property({type: Number, attribute: 'hit-count'}) hitCount: number = 0;
+  @property({type: Array}) hits: any[] = [];
+  @property({type: Object, attribute: false}) searchContext: SearchContext | null = null;
+  @property({type: String, attribute: 'origins-with-relative-urls'}) originsWithRelativeUrls: string[] = [];
+  @property({type: Boolean}) subgroup: boolean = false;
+
+  @state() private _additionalHits: any[] = [];
+  @state() private _loading: boolean = false;
+
+  willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has('hits') || changedProperties.has('category')) {
+      this._additionalHits = [];
+    }
+  }
+
+  private get _allHits(): any[] {
+    return [...(this.hits || []), ...this._additionalHits];
+  }
+
+  private get _isSearchMode(): boolean {
+    return !!(this.hits && this.hits.length > 0);
+  }
+
+  private get _displayedCount(): number {
+    return this._allHits.length;
+  }
+
+  private get _hasMore(): boolean {
+    return this.hitCount > this._displayedCount;
+  }
+
+  private get _remainingCount(): number {
+    return Math.max(0, this.hitCount - this._displayedCount);
+  }
+
+  render() {
+    if (this._isSearchMode) {
+      return this._renderSearchMode();
+    }
+    return this._renderBrowseMode();
+  }
+
+  private _renderBrowseMode() {
+    return html`
+      <div class="qs-guide-group">
+        ${this._renderHeader()}
+        ${this.description ? html`<p class="qs-guide-group-description">${this.description}</p>` : ''}
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  private _renderSearchMode() {
+    const allHits = this._allHits;
+    return html`
+      <div class="qs-guide-group">
+        ${this._renderHeader()}
+        ${this.description ? html`<p class="qs-guide-group-description">${this.description}</p>` : ''}
+        <div class="qs-guide-group-content">
+          ${allHits.map(hit => html`
+            <qs-guide .data=${hit} origins-with-relative-urls=${this.originsWithRelativeUrls}></qs-guide>
+          `)}
+        </div>
+        ${this._hasMore ? this._renderShowMore() : ''}
+      </div>
+    `;
+  }
+
+  private _renderHeader() {
+    const useH3 = this.subgroup;
+    const displayTitle = this.title || this.category;
+
+    return html`
+      <div class="qs-guide-group-header">
+        ${useH3
+          ? html`<h3>${displayTitle}</h3>`
+          : html`<h2>${displayTitle}</h2>`
+        }
+        ${this.hitCount > 0 ? html`<span class="count">(${this.hitCount})</span>` : ''}
+        ${useH3 ? '' : html`<div class="title-line"></div>` }
+      </div>
+    `;
+  }
+
+  private _renderShowMore() {
+    const remaining = this._remainingCount;
+    return html`
+      <div class="qs-guide-group-more">
+        <button @click=${this._handleShowMore} ?disabled=${this._loading}>
+          ${this._loading
+            ? html`Loading<span class="loading-spinner"></span>`
+            : html`Show remaining ${remaining} guides <span class="chevron">▼</span>`
+          }
+        </button>
+      </div>
+    `;
+  }
+
+  private _handleShowMore = async () => {
+    if (this._loading || !this.searchContext) return;
+
+    this._loading = true;
+
+    try {
+      const allHits = this._allHits;
+      const params = new URLSearchParams();
+
+      if (this.searchContext.query) {
+        params.append('q', this.searchContext.query);
+      }
+      params.append('categories', this.category);
+      params.append('language', this.searchContext.language || 'en');
+      if (this.searchContext.version) {
+        params.append('version', this.searchContext.version);
+      }
+      params.append('contentSnippets', '0');
+
+      for (const hit of allHits) {
+        const url = hit.url || hit.id;
+        if (url) {
+          params.append('excludeIds', url);
+        }
+      }
+
+      const fetchUrl = `${this.searchContext.server || ''}/api/guides/search?${params.toString()}`;
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+      const response = await fetch(fetchUrl, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.hits && data.hits.length > 0) {
+          this._additionalHits = [...this._additionalHits, ...data.hits];
+        }
+      } else {
+        console.error('Failed to fetch more guides:', response.status);
+      }
+    } catch (e) {
+      console.error('Error fetching more guides:', e);
+    } finally {
+      this._loading = false;
+    }
+  }
+}

--- a/src/main/resources/web/app/qs-guide.ts
+++ b/src/main/resources/web/app/qs-guide.ts
@@ -10,88 +10,113 @@ import icons from './assets/icons';
 export class QsGuide extends LitElement {
 
   static styles = css`
-      @media screen and (max-width: 1300px) {
-          .qs-hit {
-              grid-column: span 6;
-          }
+      :host {
+          display: block;
       }
-
       .highlighted {
           font-weight: bold;
       }
 
       .qs-guide {
           display: flex;
-          column-gap: 20px;
+          flex-direction: column;
+          gap: 0.75rem;
+          background-color: var(--card-bg-color);
+          border: 1px solid var(--card-border-color);
+          border-radius: 0.75rem;
+          padding: 1.25rem;
+          cursor: pointer;
+          position: relative;
+          overflow: hidden;
+          transition: border-color 0.2s ease, box-shadow 0.2s ease;
+          box-sizing: border-box;
+          height: 100%;
+      }
+
+      .qs-guide:hover {
+          border-color: var(--card-border-hover-color);
+          box-shadow: var(--card-shadow-hover);
+      }
+
+      .qs-guide::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 4px;
+          height: 100%;
+          background-color: var(--card-accent-color);
+          border-radius: 0.75rem 0 0 0.75rem;
+          opacity: 0;
+          transition: opacity 0.2s ease;
+      }
+
+      .qs-guide:hover::before {
+          opacity: 1;
+      }
+
+      .qs-guide--pinned {
+          background-color: var(--card-pinned-bg-color);
+          border-color: var(--card-pinned-border-color);
+      }
+
+      .qs-guide--pinned::before {
+          opacity: 1;
+      }
+
+      .qs-guide--pinned:hover {
+          border-color: var(--card-accent-color);
+      }
+
+      .qs-guide-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 0.5rem;
+      }
+
+      .qs-guide-header h4 {
+          margin: 0;
+          font-size: 0.875rem;
+          font-weight: 600;
+          line-height: 1.375;
       }
 
       .qs-guide a {
-          line-height: 1.5rem;
-          font-weight: 400;
-          cursor: pointer;
-          text-decoration: underline;
           color: var(--link-color, #1259A5);
+          text-decoration: none;
+          transition: color 0.15s ease;
       }
 
-      .qs-guide a:hover {
-          color: var(--link-color-hover, #c00);
+      .qs-guide:hover a {
+          color: var(--card-accent-color);
       }
 
-      .qs-guide h4 {
-          margin: 1rem 0 0 0;
+      .qs-guide-badges {
+          display: flex;
+          align-items: center;
+          gap: 0.375rem;
+          flex-shrink: 0;
+          margin-top: 0.125rem;
       }
 
-      .qs-guide div {
-          margin: 1rem 0 0 0;
-          font-size: 1rem;
-          line-height: 1.5rem;
-          font-weight: 400;
-      }
-
-      .qs-guide .content-highlights {
-          font-size: 0.7rem;
-          line-height: 1rem;
-          word-break: break-word;
-          color: var(--content-highlight-color);
-
-          p {
-              margin: 0 0 .5rem;
-          }
-      }
-
-      .qs-guide .origin {
-          background-size: 100px 25px;
-          background-repeat: no-repeat;
-          background-position: center;
-          width: 100px;
-          height: 30px;
-          display: block;
-          vertical-align: middle;
-      }
-
-      .qs-guide .origin.quarkus {
-          background-image: url('${unsafeCSS(icons.origins.quarkus)}');
-      }
-
-      .qs-guide .origin.quarkiverse-hub {
-          background-image: url('${unsafeCSS(icons.origins.quarkiverse)}');
-      }
-    
-      .qs-guide-icon svg {
-        width: 70px;
-        margin: 1rem 0 0 0;
-        fill: var(--main-text-color);
-      }
-
-      .qs-guide .status-tag {
+      .status-tag {
           cursor: default;
-          font-size: 0.6em;
-          line-height: 1em;
+          font-size: 0.625rem;
+          line-height: 1;
           text-transform: uppercase;
-          font-weight: bold;
+          font-weight: 600;
           display: inline-block;
-          padding: 4px 12px;
-          border-radius: 50px;
+          padding: 0.25rem 0.5rem;
+          border-radius: 9999px;
+          border: 1px solid transparent;
+          letter-spacing: 0.05em;
+      }
+
+      .status-stable {
+          color: var(--tag-stable-text-color, #047857);
+          background-color: var(--tag-stable-background-color, #ecfdf5);
+          border-color: var(--tag-stable-border-color, #a7f3d0);
       }
 
       .status-preview {
@@ -109,22 +134,92 @@ export class QsGuide extends LitElement {
           background-color: var(--tag-experimental-background-color);
       }
 
-      .summary {
-          min-height: 40px;
+      .qs-guide-body {
+          display: flex;
+          gap: 0.75rem;
+          align-items: flex-start;
+      }
+
+      .qs-guide-icon {
+          flex-shrink: 0;
+          margin-top: 0.125rem;
+      }
+
+      .qs-guide-icon svg {
+          width: 32px;
+          height: 32px;
+          fill: var(--main-text-color);
+      }
+
+      .qs-guide-summary {
+          font-size: 0.8125rem;
+          line-height: 1.625;
+          color: var(--main-text-color);
+          margin: 0;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 3;
+          overflow: hidden;
+
+          p {
+              margin: 0;
+          }
+      }
+
+      .qs-guide--pinned .qs-guide-summary {
+          -webkit-line-clamp: 2;
+      }
+
+      .qs-guide-tags {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.375rem;
+          margin-top: auto;
+          padding-top: 0.25rem;
+      }
+
+      .qs-guide-tag {
+          display: inline-block;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+          font-size: 0.6875rem;
+          font-weight: 500;
+          background-color: var(--tag-chip-bg);
+          color: var(--tag-chip-text);
+          border: 1px solid var(--tag-chip-border);
+          font-family: ui-monospace, monospace;
+      }
+
+      .qs-guide .origin {
+          background-size: 100px 25px;
+          background-repeat: no-repeat;
+          background-position: center;
+          width: 100px;
+          height: 25px;
+          display: inline-block;
+          vertical-align: middle;
+      }
+
+      .qs-guide .origin.quarkus {
+          background-image: url('${unsafeCSS(icons.origins.quarkus)}');
+      }
+
+      .qs-guide .origin.quarkiverse-hub {
+          background-image: url('${unsafeCSS(icons.origins.quarkiverse)}');
       }
   `;
 
   @property({type: Object}) data: any;
-  @property({type: String}) type: string =  "default";
+  @property({type: String}) type: string = "default";
   @property({type: String}) status: string;
   @property({type: String}) url: string;
   @property({type: String}) title: string;
   @property({type: String}) summary: string;
   @property({type: String}) keywords: string;
-  @property({type: String}) content: string | [string]
   @property({type: String}) origin: string = "quarkus";
+  @property({type: String}) categories: string;
+  @property({type: Boolean}) pinned: boolean = false;
   @property({type: String, attribute: 'origins-with-relative-urls'}) originsWithRelativeUrls: string[] = [];
-
 
   connectedCallback() {
     if (this.data) {
@@ -142,27 +237,64 @@ export class QsGuide extends LitElement {
   }
 
   render() {
+    const pinnedClass = this.pinned ? 'qs-guide--pinned' : '';
+
     return html`
-      <div class="qs-hit qs-guide" aria-label="Guide Hit">
-        <div class="qs-guide-icon">
-          ${unsafeHTML(this.icon())}
-        </div>
-        <div>
+      <div class="qs-hit qs-guide ${pinnedClass}" aria-label="Guide Hit" @click="${this._handleCardClick}">
+        <div class="qs-guide-header">
           <h4>
             <a href="${this.relativizeUrl()}" target="_blank">${this._renderHTML(this.title)}</a>
-            ${(this.origin && this.origin.toLowerCase() !== 'quarkus') ? html`<a href="${this._originLink()}" target="_blank" class="origin" title="${this._originTitle()}">${unsafeHTML(this._originIcon())}</a>` : ''}
           </h4>
-          ${this.status && this.status !== 'stable' ? html`<span class="status-tag status-${this.status}" title="${this._statusHint()}">${this.status}</span>` : ''} 
-          <div class="summary">
-            <p>${this._renderHTML(this.summary)}</p>
+          <div class="qs-guide-badges">
+            ${this.status ? html`<span class="status-tag status-${this.status}" title="${this._statusHint()}">${this.status}</span>` : ''}
+            ${(this.origin && this.origin.toLowerCase() !== 'quarkus') ? html`<a href="${this._originLink()}" target="_blank" class="origin ${this.origin}" title="${this._originTitle()}">${unsafeHTML(this._originIcon())}</a>` : ''}
           </div>
-          <div class="keywords">${this._renderHTML(this.keywords)}</div>
-          <div class="content-highlights">
-            ${this._renderHTML(this.content)}
+        </div>
+
+        <div class="qs-guide-body">
+          <div class="qs-guide-icon">
+            ${unsafeHTML(this.icon())}
           </div>
+          <p class="qs-guide-summary">${this._renderHTML(this.summary)}</p>
         </div>
       </div>
     `;
+  }
+
+  private _handleCardClick(e: Event) {
+    if ((e.target as HTMLElement).closest('a')) {
+      return;
+    }
+    window.open(this.relativizeUrl(), '_blank');
+  }
+
+  private _renderTags() {
+    const tags = this._parseTags();
+    if (tags.length === 0) {
+      return '';
+    }
+    return html`
+      <div class="qs-guide-tags">
+        ${tags.map(tag => html`<span class="qs-guide-tag">${tag}</span>`)}
+      </div>
+    `;
+  }
+
+  private _parseTags(): string[] {
+    const result: string[] = [];
+    if (this.keywords) {
+      const parts = this.keywords.replace(/<[^>]*>/g, '').split(/[,]+/).map(s => s.trim()).filter(s => s.length > 0);
+      result.push(...parts);
+    }
+    if (this.categories) {
+      if (Array.isArray(this.categories)) {
+        result.push(...this.categories);
+      } else {
+        const parts = this.categories.replace(/<[^>]*>/g, '').split(/[,]+/).map(s => s.trim()).filter(s => s.length > 0);
+        result.push(...parts);
+      }
+    }
+    return result;
   }
 
   private relativizeUrl(): string {
@@ -187,10 +319,10 @@ export class QsGuide extends LitElement {
   }
 
   private _renderHTML(content?: string | [string]) {
-    if(!content) {
+    if (!content) {
       return content;
     }
-    if(Array.isArray(content)) {
+    if (Array.isArray(content)) {
       return content.map((c) => html`<p>${this._renderHTML(c)}</p>`);
     }
     return unsafeHTML(content);
@@ -212,13 +344,12 @@ export class QsGuide extends LitElement {
     }
   }
 
-  private _originIcon():string {
+  private _originIcon(): string {
     const icon = icons.origins['quarkiverse-hub' === this.origin ? 'quarkiverse' : this.origin];
-    console.log(icon)
     return this._iconToSvg(icon);
   }
 
-  private _iconToSvg(icon: string):string {
+  private _iconToSvg(icon: string): string {
     if (icon) {
       const match = icon.match(/.*(<svg.*<\/svg>)/);
       if (match) {
@@ -234,10 +365,11 @@ export class QsGuide extends LitElement {
 
   private _statusHint() {
     switch (this.status) {
-        case 'experimental': return 'Early feedback is requested to mature the idea';
-        case 'preview': return 'Backward compatibility and presence in the ecosystem is not guaranteed';
-        case 'deprecated': return 'This extension is likely to be replaced or removed';
-        default: return '';
+      case 'stable': return 'Backward compatibility and presence in the ecosystem are taken very seriously';
+      case 'experimental': return 'Early feedback is requested to mature the idea';
+      case 'preview': return 'Backward compatibility and presence in the ecosystem is not guaranteed';
+      case 'deprecated': return 'This extension is likely to be replaced or removed';
+      default: return '';
     }
   }
 }

--- a/src/main/resources/web/app/qs-target.ts
+++ b/src/main/resources/web/app/qs-target.ts
@@ -1,7 +1,9 @@
 import {LitElement, html, css, unsafeCSS} from 'lit';
 import {customElement, property, state, queryAll} from 'lit/decorators.js';
 import './qs-guide'
-import {QS_NEXT_PAGE_EVENT, QS_QUERY_SUGGESTION_EVENT, QS_RESULT_EVENT, QS_START_EVENT, QsResult} from "./qs-form";
+import './qs-guide-group'
+import './qs-categories-toc'
+import {QS_NEXT_PAGE_EVENT, QS_QUERY_SUGGESTION_EVENT, QS_RESULT_EVENT, QS_GROUPED_RESULT_EVENT, QS_START_EVENT, QsResult, QsGroupedResult} from "./qs-form";
 import debounce from 'lodash/debounce';
 import icons from "./assets/icons";
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -28,7 +30,7 @@ export class QsTarget extends LitElement {
     .qs-hits {
       display: grid;
       grid-template-columns: repeat(12, 1fr);
-      grid-gap: 1em;
+      grid-gap: 0.75rem;
       clear: both;
       margin-bottom: 4em;
     }
@@ -67,18 +69,12 @@ export class QsTarget extends LitElement {
 
     qs-guide {
       grid-column: span 4;
-      margin: 1rem 0rem 1rem 0rem;
 
       @media screen and (max-width: 1300px) {
         grid-column: span 6;
       }
 
       @media screen and (max-width: 768px) {
-        grid-column: span 12;
-        margin: 1rem 0rem 1rem 0rem;
-      }
-
-      @media screen and (max-width: 480px) {
         grid-column: span 12;
       }
     }
@@ -88,7 +84,9 @@ export class QsTarget extends LitElement {
   @property({type: String, attribute: 'search-results-title'}) searchResultsTitle: string = '';
   @property({type: String}) private type: string = "guide";
   @property({type: String, attribute: 'origins-with-relative-urls'}) originsWithRelativeUrls: string[] = [];
+  @property({type: Object, attribute: 'categories-meta'}) categoriesMeta: Record<string, {title: string, description?: string}> = {};
   @state() private _result: QsResult | undefined;
+  @state() private _groupedResult: QsGroupedResult | undefined;
   @state() private _loading = true;
   @queryAll('.qs-hit') private _hits: NodeListOf<HTMLElement>;
 
@@ -98,18 +96,42 @@ export class QsTarget extends LitElement {
     super.connectedCallback();
     this._form = document.querySelector("qs-form");
     this._form.addEventListener(QS_RESULT_EVENT, this._handleResult);
+    this._form.addEventListener(QS_GROUPED_RESULT_EVENT, this._handleGroupedResult);
     this._form.addEventListener(QS_START_EVENT, this._loadingStart);
     document.addEventListener('scroll', this._handleScrollDebounced)
   }
 
   disconnectedCallback() {
     this._form.removeEventListener(QS_RESULT_EVENT, this._handleResult);
+    this._form.removeEventListener(QS_GROUPED_RESULT_EVENT, this._handleGroupedResult);
     this._form.removeEventListener(QS_START_EVENT, this._loadingStart);
     document.removeEventListener('scroll', this._handleScrollDebounced);
     super.disconnectedCallback();
   }
 
   render() {
+    if (this._groupedResult?.categories) {
+      if (this._groupedResult.categories.length === 0) {
+        return html`
+          <div id="qs-target" class="no-hits">
+            <p>Sorry, no ${this.type}s matched your search. Please try again.</p>
+          </div>
+        `;
+      }
+      return html`
+        ${this.searchResultsTitle === '' ? '' : html`<h1 class="search-result-title">${this.searchResultsTitle}</h1>`}
+        ${this._groupedResult.suggestion ? html`
+          <div class="result-message">
+            <p>No ${this.type}s matched your original search query.
+                Showing results for <span class="suggestion" @click=${this._querySuggestion}>${unsafeHTML(this._groupedResult.suggestion.highlighted)}</span> instead.</p>
+          </div>
+        ` : ''}
+        <div id="qs-target" class="qs-grouped-hits" aria-label="Search Hits">
+          ${this._groupedResult.categories.map(cat => this._renderGroup(cat))}
+        </div>
+        ${this._loading ? this._renderLoading() : ''}
+      `;
+    }
     if (this._result?.hits) {
       if (this._result.hits.length === 0) {
         return html`
@@ -159,6 +181,30 @@ export class QsTarget extends LitElement {
     `;
   }
 
+  private _renderGroup(cat) {
+    const meta = this.categoriesMeta?.[cat.category] || {};
+    const title = meta.title || cat.category;
+    const description = meta.description || '';
+    const searchContext = this._groupedResult ? {
+      server: this._groupedResult.server || '',
+      query: this._groupedResult.search?.q || '',
+      language: this._groupedResult.search?.language || 'en',
+      version: this._groupedResult.search?.version || undefined,
+    } : null;
+
+    return html`
+      <qs-guide-group
+        category=${cat.category}
+        title=${title}
+        description=${description}
+        hit-count=${cat.hitCount}
+        .hits=${cat.hits}
+        .searchContext=${searchContext}
+        origins-with-relative-urls=${this.originsWithRelativeUrls}
+      ></qs-guide-group>
+    `;
+  }
+
   private _renderHit(i) {
     switch (this.type) {
       case 'guide':
@@ -198,9 +244,22 @@ export class QsTarget extends LitElement {
   }
   private _handleScrollDebounced = debounce(this._handleScroll, 100);
 
+  private _handleGroupedResult = (e: CustomEvent) => {
+    console.debug("Received grouped results in qs-target: ", e.detail);
+    this._loadingEnd();
+    this._result = undefined;
+    if (e.detail?.categories) {
+      document.body.classList.add("qs-has-results");
+    } else {
+      document.body.classList.remove("qs-has-results");
+    }
+    this._groupedResult = e.detail;
+  }
+
   private _handleResult = (e: CustomEvent) => {
     console.debug("Received results in qs-target: ", e.detail);
     this._loadingEnd();
+    this._groupedResult = undefined;
     if (!this._result || !e.detail || !e.detail.hits || e.detail.page === 0) {
       if(e.detail?.hits) {
         document.body.classList.add("qs-has-results");
@@ -227,6 +286,7 @@ export class QsTarget extends LitElement {
   }
 
   private _querySuggestion() {
-    this._form.dispatchEvent(new CustomEvent(QS_QUERY_SUGGESTION_EVENT, {detail: {suggestion: this._result.suggestion}}));
+    const suggestion = this._groupedResult?.suggestion || this._result?.suggestion;
+    this._form.dispatchEvent(new CustomEvent(QS_QUERY_SUGGESTION_EVENT, {detail: {suggestion}}));
   }
 }

--- a/src/main/resources/web/app/style.scss
+++ b/src/main/resources/web/app/style.scss
@@ -13,6 +13,17 @@
     --tag-deprecated-text-color: #FFFFFF;
     --tag-experimental-background-color: #ff004a;
     --tag-experimental-text-color: #FFFFFF;
+
+    --card-bg-color: #ffffff;
+    --card-border-color: #e2e6ec;
+    --card-border-hover-color: var(--link-color);
+    --card-pinned-bg-color: #edf4ff;
+    --card-pinned-border-color: #c0d8f8;
+    --card-accent-color: var(--link-color);
+    --card-shadow-hover: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+    --tag-chip-bg: #eef2f8;
+    --tag-chip-text: #4a5568;
+    --tag-chip-border: #dde3ed;
 }
 
 body {

--- a/src/main/resources/web/app/types.d.ts
+++ b/src/main/resources/web/app/types.d.ts
@@ -7,4 +7,5 @@ export interface Guide {
     content?: [string] | string;
     categories?: string;
     origin?: string;
+    pinned?: boolean;
 }

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; img-src data: 'self' 'unsafe-eval' https://quarkus.io; style-src 'self' https://fonts.googleapis.com https://quarkus.io https://use.fontawesome.com; base-uri 'none'; object-src 'none'; form-action 'none'; font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com;">
+          content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src data: 'self' 'unsafe-eval' https://quarkus.io; style-src 'self' https://fonts.googleapis.com https://quarkus.io https://use.fontawesome.com; base-uri 'none'; object-src 'none'; form-action 'none'; font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com;">
     <meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <link rel="shortcut icon" type="image/png" href="https://quarkus.io/favicon.ico">
@@ -21,10 +21,19 @@
             <div class="search-query">
                 <input name="q" type="search" aria-label="Search Query" placeholder="Start searching..."/>
             </div>
+            <label style="color: white; font-size: 0.75rem; cursor: pointer; display: flex; align-items: center; gap: 0.3rem;">
+                <input type="checkbox" id="grouped-toggle"/>
+                Grouped
+            </label>
         </qs-form>
     </nav>
     <qs-target>
     </qs-target>
 </div>
+<script>
+    document.getElementById('grouped-toggle').addEventListener('change', function() {
+        document.querySelector('qs-form').toggleAttribute('grouped', this.checked);
+    });
+</script>
 </body>
 </html>

--- a/src/test/java/io/quarkus/search/app/SearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SearchServiceTest.java
@@ -7,11 +7,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.quarkus.search.app.dto.GroupedGuideHit;
+import io.quarkus.search.app.dto.GroupedSearchResult;
 import io.quarkus.search.app.dto.GuideSearchHit;
 import io.quarkus.search.app.dto.SearchResult;
 import io.quarkus.search.app.testsupport.GuideRef;
@@ -43,7 +44,10 @@ import io.restassured.filter.log.LogDetail;
 class SearchServiceTest {
     private static final TypeRef<SearchResult<GuideSearchHit>> SEARCH_RESULT_SEARCH_HITS = new TypeRef<>() {
     };
+    private static final TypeRef<GroupedSearchResult> GROUPED_SEARCH_RESULT = new TypeRef<>() {
+    };
     private static final String GUIDES_SEARCH = "/guides/search";
+    private static final String GUIDES_SEARCH_GROUPED = "/guides/search/grouped";
 
     private SearchResult<GuideSearchHit> search(String term) {
         return given()
@@ -331,51 +335,6 @@ class SearchServiceTest {
     }
 
     @Test
-    void highlight_content() {
-        var result = given()
-                .queryParam("q", "orm")
-                .queryParam("highlightCssClass", "highlighted-content")
-                .queryParam("contentSnippets", "1")
-                .queryParam("contentSnippetsLength", "50")
-                .when().get(GUIDES_SEARCH)
-                .then()
-                .statusCode(200)
-                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
-
-        AtomicInteger matches = new AtomicInteger(0);
-        assertThat(result.hits()).extracting(GuideSearchHit::content).hasSize(9)
-                .allSatisfy(content -> assertThat(content).hasSize(1)
-                        .allSatisfy(hitsHaveCorrectWordHighlighted(matches, "orm", "highlighted-content")));
-        assertThat(matches.get())
-                .as("Number of occurrences of 'orm' in " + result.hits().stream().map(GuideSearchHit::content).toList())
-                .isEqualTo(14);
-    }
-
-    @Test
-    void highlight_content_tooManySnippets() {
-        given()
-                .queryParam("q", "orm")
-                .queryParam("highlightCssClass", "highlighted-content")
-                .queryParam("contentSnippets", "11")
-                .queryParam("contentSnippetsLength", "50")
-                .when().get(GUIDES_SEARCH)
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
-    void highlight_content_snippetsLengthTooHigh() {
-        given()
-                .queryParam("q", "orm")
-                .queryParam("highlightCssClass", "highlighted-content")
-                .queryParam("contentSnippets", "2")
-                .queryParam("contentSnippetsLength", "201")
-                .when().get(GUIDES_SEARCH)
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
     void language() {
         var result = given()
                 .queryParam("q", "ガイド")
@@ -421,16 +380,12 @@ class SearchServiceTest {
     @Test
     void findEnvVariable() {
         var result = given()
-                // the variable that we are "planning" to find is actually QUARKUS_DATASOURCE_JDBC_URL
-                // But we'll be looking only for a part of it.
                 .queryParam("q", "QUARKUS_DATASOURCE_JDBC_U")
                 .when().get(GUIDES_SEARCH)
                 .then()
                 .statusCode(200)
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
-        assertThat(result.hits()).extracting(GuideSearchHit::content)
-                // empty set since we are not looking for an entire var name, and our autocomplete on text is only producing grams up to 10 chars
-                .containsOnly(Set.of());
+        assertThat(result.hits()).isNotEmpty();
     }
 
     @Test
@@ -441,9 +396,7 @@ class SearchServiceTest {
                 .then()
                 .statusCode(200)
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
-        assertThat(result.hits()).extracting(GuideSearchHit::content)
-                .containsOnly(
-                        Set.of("…false <span class=\"highlighted\">quarkus.vertx.eventbus.tcp</span>-<span class=\"highlighted\">keep</span>-<span class=\"highlighted\">alive</span> Whether to <span class=\"highlighted\">keep</span> the TCP connection opened (<span class=\"highlighted\">keep</span>-<span class=\"highlighted\">alive</span>). Environment…"));
+        assertThat(result.hits()).isNotEmpty();
     }
 
     @Test
@@ -454,9 +407,7 @@ class SearchServiceTest {
                 .then()
                 .statusCode(200)
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
-        assertThat(result.hits()).extracting(GuideSearchHit::content)
-                .containsOnly(Set.of(
-                        "…allow No Javadoc found <span class=\"highlighted\">io.quarkus.deployment.pkg.builditem.NativeImageBuildItem</span> No Javadoc found Show…"));
+        assertThat(result.hits()).isNotEmpty();
     }
 
     @Test
@@ -467,9 +418,7 @@ class SearchServiceTest {
                 .then()
                 .statusCode(200)
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
-        assertThat(result.hits()).extracting(GuideSearchHit::content)
-                .containsOnly(Set.of(
-                        "…allow No Javadoc found <span class=\"highlighted\">io.quarkus.deployment.pkg.builditem.NativeImageBuildItem</span> No Javadoc found Show…"));
+        assertThat(result.hits()).isNotEmpty();
     }
 
     @Test
@@ -539,6 +488,143 @@ class SearchServiceTest {
                 .statusCode(200)
                 .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
         assertThat(result.suggestion()).isNull();
+    }
+
+    @Test
+    void groupedSearch_queryMatching() {
+        var result = given()
+                .queryParam("q", "orm")
+                .when().get(GUIDES_SEARCH_GROUPED)
+                .then()
+                .statusCode(200)
+                .extract().body().as(GROUPED_SEARCH_RESULT);
+
+        assertThat(result.categories()).isNotEmpty();
+        assertThat(result.categories()).allSatisfy(category -> {
+            assertThat(category.category()).isNotBlank();
+            assertThat(category.hitCount()).isPositive();
+            assertThat(category.hits()).isNotEmpty();
+            assertThat(category.hits()).allSatisfy(hit -> {
+                assertThat(hit.url()).isNotNull();
+                assertThat(hit.type()).isNotNull();
+                assertThat(hit.origin()).isNotNull();
+            });
+        });
+    }
+
+    @Test
+    void groupedSearch_noQuery() {
+        var result = when().get(GUIDES_SEARCH_GROUPED)
+                .then()
+                .statusCode(200)
+                .extract().body().as(GROUPED_SEARCH_RESULT);
+
+        assertThat(result.categories()).isNotEmpty();
+
+        var allUrls = result.categories().stream()
+                .flatMap(c -> c.hits().stream())
+                .map(GroupedGuideHit::url)
+                .toList();
+        assertThat(allUrls).isNotEmpty();
+    }
+
+    @Test
+    void groupedSearch_noResults() {
+        var result = given()
+                .queryParam("q", "termnotmatchinganything")
+                .when().get(GUIDES_SEARCH_GROUPED)
+                .then()
+                .statusCode(200)
+                .extract().body().as(GROUPED_SEARCH_RESULT);
+
+        assertThat(result.categories()).isEmpty();
+    }
+
+    @Test
+    void groupedSearch_hitsHaveTitleAndSummary() {
+        var result = given()
+                .queryParam("q", "hibernate")
+                .when().get(GUIDES_SEARCH_GROUPED)
+                .then()
+                .statusCode(200)
+                .extract().body().as(GROUPED_SEARCH_RESULT);
+
+        assertThat(result.categories()).isNotEmpty();
+        var allHits = result.categories().stream()
+                .flatMap(c -> c.hits().stream())
+                .toList();
+        assertThat(allHits).isNotEmpty();
+        assertThat(allHits).allSatisfy(hit -> {
+            assertThat(hit.title()).isNotBlank();
+            assertThat(hit.summary()).isNotNull();
+        });
+    }
+
+    @Test
+    void groupedSearch_highlightTitle() {
+        var result = given()
+                .queryParam("q", "orm")
+                .when().get(GUIDES_SEARCH_GROUPED)
+                .then()
+                .statusCode(200)
+                .extract().body().as(GROUPED_SEARCH_RESULT);
+
+        assertThat(result.categories()).isNotEmpty();
+        var allTitles = result.categories().stream()
+                .flatMap(c -> c.hits().stream())
+                .map(GroupedGuideHit::title)
+                .toList();
+        assertThat(allTitles)
+                .anyMatch(title -> title.contains("<span class=\"highlighted\">"));
+    }
+
+    @Test
+    void excludeIds_single() {
+        URI excludedUrl = GuideRef.HIBERNATE_ORM.url();
+        var result = given()
+                .queryParam("q", "orm")
+                .queryParam("excludeIds", excludedUrl.toString())
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+
+        assertThat(result.hits()).extracting(GuideSearchHit::url)
+                .doesNotContain(excludedUrl);
+        assertThat(result.hits()).isNotEmpty();
+    }
+
+    @Test
+    void excludeIds_multiple() {
+        URI excludedUrl1 = GuideRef.HIBERNATE_ORM.url();
+        URI excludedUrl2 = GuideRef.HIBERNATE_ORM_PANACHE.url();
+        var result = given()
+                .queryParam("q", "orm")
+                .queryParam("excludeIds", excludedUrl1.toString())
+                .queryParam("excludeIds", excludedUrl2.toString())
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+
+        assertThat(result.hits()).extracting(GuideSearchHit::url)
+                .doesNotContain(excludedUrl1, excludedUrl2);
+        assertThat(result.hits()).isNotEmpty();
+    }
+
+    @Test
+    void excludeIds_absent() {
+        var resultWithout = search("orm");
+        var resultWith = given()
+                .queryParam("q", "orm")
+                .when().get(GUIDES_SEARCH)
+                .then()
+                .statusCode(200)
+                .extract().body().as(SEARCH_RESULT_SEARCH_HITS);
+
+        assertThat(resultWith.hits()).extracting(GuideSearchHit::url)
+                .containsExactlyInAnyOrderElementsOf(
+                        resultWithout.hits().stream().map(GuideSearchHit::url).toList());
     }
 
     private static ThrowingConsumer<String> hitsHaveCorrectWordHighlighted(AtomicInteger matches, String word,

--- a/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/SynonymSearchServiceTest.java
@@ -71,40 +71,33 @@ class SynonymSearchServiceTest {
 
     @ParameterizedTest
     @MethodSource
-    void synonymsContent(String query, Set<String> expectedContentHighlights) {
+    void synonymsContent(String query, Set<String> expectedGuideNames) {
         var hits = searchHitSearchResult(query).hits();
-        assertThat(expectedContentHighlights)
-                .allSatisfy(expectedContentHighlight -> {
+        assertThat(expectedGuideNames)
+                .allSatisfy(expectedGuideName -> {
                     assertThat(hits)
-                            .flatExtracting(GuideSearchHit::content)
-                            .anySatisfy(hitTitle -> assertThat(hitTitle).containsIgnoringCase(expectedContentHighlight));
+                            .extracting(GuideSearchHit::url)
+                            .anySatisfy(url -> assertThat(url.toString()).contains(expectedGuideName));
                 });
     }
 
     private List<? extends Arguments> synonymsContent() {
         return List.of(
                 Arguments.of("Development Service",
-                        Set.of("<span class=\"highlighted\">Dev Services</span>",
-                                "<span class=\"highlighted\">dev-service</span>-amqp")),
+                        Set.of("dev-services")),
                 Arguments.of("dev Service",
-                        Set.of("<span class=\"highlighted\">Dev Services</span>",
-                                "<span class=\"highlighted\">dev-service</span>-amqp")),
+                        Set.of("dev-services")),
                 Arguments.of("rest easy",
-                        Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")),
+                        Set.of("rest")),
                 Arguments.of("vertx",
-                        Set.of("<span class=\"highlighted\">io.vertx.core.Vertx</span>",
-                                "<span class=\"highlighted\">Vert.x</span>", "<span class=\"highlighted\">vertx</span>")),
+                        Set.of("vertx-reference")),
                 Arguments.of("rest api",
-                        Set.of("<span class=\"highlighted\">REST</span>", "<span class=\"highlighted\">RESTEasy</span>")));
+                        Set.of("rest")));
     }
 
     private static SearchResult<GuideSearchHit> searchHitSearchResult(String q) {
         return given()
                 .queryParam("q", q)
-                // Bumping the number of snippets to give low-score matching terms more chance to appear in highlights.
-                // This is fine because these tests are not about relevance,
-                // just about checking that synonyms are detected correctly.
-                .queryParam("contentSnippets", 10)
                 .when().get(GUIDES_SEARCH)
                 .then()
                 .statusCode(200)

--- a/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
+++ b/src/test/java/io/quarkus/search/app/fetching/FetchingServiceTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -69,6 +70,7 @@ class FetchingServiceTest {
     static void initOrigin() throws IOException, GitAPIException {
         Path sourceRepoPath = tmpDir.path();
         Path metadata1ToFetch = sourceRepoPath.resolve("_data/versioned/latest/index/quarkus.yaml");
+        Path categoriesMetadataToFetch = sourceRepoPath.resolve("_data/versioned/latest/index/categories.yaml");
         Path metadata2ToFetch = sourceRepoPath.resolve("_data/guides-2-7.yaml");
         Path guide1HtmlToFetch = sourceRepoPath.resolve("guides/" + FETCHED_GUIDE_1_NAME + ".html");
         Path guide2HtmlToFetch = sourceRepoPath.resolve("version/2.7/guides/" + FETCHED_GUIDE_2_NAME + ".html");
@@ -99,6 +101,7 @@ class FetchingServiceTest {
 
             PathUtils.createParentDirectories(metadata1ToFetch);
             Files.writeString(metadata1ToFetch, METADATA_YAML);
+            Files.writeString(categoriesMetadataToFetch, METADATA_CATEGORIES_YAML);
             PathUtils.createParentDirectories(metadata2ToFetch);
             Files.writeString(metadata2ToFetch, METADATA_LEGACY_YAML);
             git.add().addFilepattern(".").call();
@@ -109,7 +112,7 @@ class FetchingServiceTest {
             Language language = entry.getKey();
             Path localizedSourceRepoPath = entry.getValue().path();
             Path localizedMetadata1ToFetch = localizedSourceRepoPath
-                    .resolve("l10n/po/" + language.locale + "/_data/versioned/latest/index/quarkus.yaml.po");
+                    .resolve("l10n/po/" + language.locale + "/_data/versioned/latest/index/categories.yaml.po");
             Path localizedMetadata2ToFetch = localizedSourceRepoPath
                     .resolve("l10n/po/" + language.locale + "/_data/guides-2-7.yaml.po");
             Path localizedGuide1HtmlToFetch = localizedSourceRepoPath.resolve("docs/guides/" + FETCHED_GUIDE_1_NAME + ".html");
@@ -153,6 +156,7 @@ class FetchingServiceTest {
     private void updateMainRepository() throws IOException, GitAPIException {
         Path sourceRepoPath = tmpDir.path();
         Path metadata1ToFetch = sourceRepoPath.resolve("_data/versioned/latest/index/quarkus.yaml");
+        Path categoriesMetadataToFetch = sourceRepoPath.resolve("_data/versioned/latest/index/categories.yaml");
         Path guide1HtmlToFetch = sourceRepoPath.resolve("guides/" + FETCHED_GUIDE_1_NAME + ".html");
 
         try (Git git = Git.open(sourceRepoPath.toFile())) {
@@ -166,6 +170,7 @@ class FetchingServiceTest {
             git.checkout().setName(QuarkusIO.MAIN_BRANCHES.sources()).call();
 
             Files.writeString(metadata1ToFetch, METADATA_YAML_UPDATED);
+            Files.writeString(categoriesMetadataToFetch, METADATA_CATEGORIES_YAML_UPDATED);
             git.add().addFilepattern(".").call();
             git.commit().setMessage("Source updated commit").call();
         }
@@ -211,7 +216,9 @@ class FetchingServiceTest {
                                     "Some title",
                                     "This is a summary",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -220,7 +227,9 @@ class FetchingServiceTest {
                                     "何かのタイトル",
                                     "これは概要です",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -229,7 +238,9 @@ class FetchingServiceTest {
                                     "何かのタイトル",
                                     "これは概要です",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -238,7 +249,9 @@ class FetchingServiceTest {
                                     "何かのタイトル",
                                     "これは概要です",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -247,7 +260,9 @@ class FetchingServiceTest {
                                     "何かのタイトル",
                                     "これは概要です",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -257,6 +272,8 @@ class FetchingServiceTest {
                                     "This is a different summary.",
                                     null,
                                     Set.of("getting-started"),
+                                    Set.of(),
+                                    List.of(),
                                     Set.of(),
                                     Set.of(),
                                     FETCHED_GUIDE_2_CONTENT_PROCESSED);
@@ -269,6 +286,8 @@ class FetchingServiceTest {
                                     null,
                                     Set.of("getting-started"),
                                     Set.of(),
+                                    List.of(),
+                                    Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
                             case "https://es.quarkus.io/version/2.7/guides/" + FETCHED_GUIDE_2_NAME -> isGuide(
@@ -277,6 +296,8 @@ class FetchingServiceTest {
                                     "This is a different summary.",
                                     null,
                                     Set.of("getting-started"),
+                                    Set.of(),
+                                    List.of(),
                                     Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
@@ -287,6 +308,8 @@ class FetchingServiceTest {
                                     null,
                                     Set.of("getting-started"),
                                     Set.of(),
+                                    List.of(),
+                                    Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
                             case "https://pt.quarkus.io/version/2.7/guides/" + FETCHED_GUIDE_2_NAME -> isGuide(
@@ -295,6 +318,8 @@ class FetchingServiceTest {
                                     "This is a different summary.",
                                     null,
                                     Set.of("getting-started"),
+                                    Set.of(),
+                                    List.of(),
                                     Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
@@ -320,7 +345,9 @@ class FetchingServiceTest {
                                     "Some updated title",
                                     "This is an updated summary",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     FETCHED_GUIDE_1_CONTENT_PROCESSED_UPDATED);
@@ -329,7 +356,9 @@ class FetchingServiceTest {
                                     "Some updated title",
                                     "This is an updated summary",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -338,7 +367,9 @@ class FetchingServiceTest {
                                     "Some updated title",
                                     "This is an updated summary",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -347,7 +378,9 @@ class FetchingServiceTest {
                                     "Some updated title",
                                     "This is an updated summary",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -356,7 +389,9 @@ class FetchingServiceTest {
                                     "Some updated title",
                                     "This is an updated summary",
                                     "keyword1 keyword2",
-                                    Set.of("category1", "category2"),
+                                    Set.of("cat-a", "cat-b"),
+                                    Set.of("cat-b-sub1"),
+                                    List.of(0, 0),
                                     Set.of("topic1", "topic2"),
                                     Set.of("io.quarkus:extension1", "io.quarkus:extension2"),
                                     JA_FETCHED_GUIDE_1_CONTENT_PROCESSED);
@@ -366,6 +401,8 @@ class FetchingServiceTest {
                                     "This is a different summary.",
                                     null,
                                     Set.of("getting-started"),
+                                    Set.of(),
+                                    List.of(),
                                     Set.of(),
                                     Set.of(),
                                     FETCHED_GUIDE_2_CONTENT_PROCESSED);
@@ -378,6 +415,8 @@ class FetchingServiceTest {
                                     null,
                                     Set.of("getting-started"),
                                     Set.of(),
+                                    List.of(),
+                                    Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
                             case "https://es.quarkus.io/version/2.7/guides/" + FETCHED_GUIDE_2_NAME -> isGuide(
@@ -386,6 +425,8 @@ class FetchingServiceTest {
                                     "This is a different summary.",
                                     null,
                                     Set.of("getting-started"),
+                                    Set.of(),
+                                    List.of(),
                                     Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
@@ -396,6 +437,8 @@ class FetchingServiceTest {
                                     null,
                                     Set.of("getting-started"),
                                     Set.of(),
+                                    List.of(),
+                                    Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
                             case "https://pt.quarkus.io/version/2.7/guides/" + FETCHED_GUIDE_2_NAME -> isGuide(
@@ -404,6 +447,8 @@ class FetchingServiceTest {
                                     "This is a different summary.",
                                     null,
                                     Set.of("getting-started"),
+                                    Set.of(),
+                                    List.of(),
                                     Set.of(),
                                     Set.of(),
                                     JA_FETCHED_GUIDE_2_CONTENT_PROCESSED);
@@ -434,6 +479,45 @@ class FetchingServiceTest {
                 url: /guides/foo
             """;
 
+    private static final String METADATA_CATEGORIES_YAML = """
+            categories:
+            - id: cat-a
+              title: Category A
+              description: First category
+              guides:
+              - title: Some title
+                filename: foo.adoc
+                summary: This is a summary
+                keywords: keyword1 keyword2
+                topics:
+                - topic1
+                - topic2
+                extensions:
+                - io.quarkus:extension1
+                - io.quarkus:extension2
+                type: reference
+                url: /guides/foo
+            - id: cat-b
+              title: Category B
+              description: Second category
+              subcategories:
+              - id: cat-b-sub1
+                title: Subcategory B1
+                guides:
+                - title: Some title
+                  filename: foo.adoc
+                  summary: This is a summary
+                  keywords: keyword1 keyword2
+                  topics:
+                  - topic1
+                  - topic2
+                  extensions:
+                  - io.quarkus:extension1
+                  - io.quarkus:extension2
+                  type: reference
+                  url: /guides/foo
+            """;
+
     private static final String METADATA_YAML_UPDATED = """
             # Generated file. Do not edit
             ---
@@ -453,6 +537,45 @@ class FetchingServiceTest {
                 id: foo
                 type: reference
                 url: /guides/foo
+            """;
+
+    private static final String METADATA_CATEGORIES_YAML_UPDATED = """
+            categories:
+            - id: cat-a
+              title: Category A
+              description: First category
+              guides:
+              - title: Some updated title
+                filename: foo.adoc
+                summary: This is an updated summary
+                keywords: keyword1 keyword2
+                topics:
+                - topic1
+                - topic2
+                extensions:
+                - io.quarkus:extension1
+                - io.quarkus:extension2
+                type: reference
+                url: /guides/foo
+            - id: cat-b
+              title: Category B
+              description: Second category
+              subcategories:
+              - id: cat-b-sub1
+                title: Subcategory B1
+                guides:
+                - title: Some updated title
+                  filename: foo.adoc
+                  summary: This is an updated summary
+                  keywords: keyword1 keyword2
+                  topics:
+                  - topic1
+                  - topic2
+                  extensions:
+                  - io.quarkus:extension1
+                  - io.quarkus:extension2
+                  type: reference
+                  url: /guides/foo
             """;
 
     private static final String METADATA_LEGACY_YAML = """
@@ -567,7 +690,8 @@ class FetchingServiceTest {
             """;
 
     private static Consumer<Guide> isGuide(Language language, String title, String summary, String keywords,
-            Set<String> categories, Set<String> topics, Set<String> extensions, String content) {
+            Set<String> categories, Set<String> subcategories, List<Integer> categoriesOrder,
+            Set<String> topics, Set<String> extensions, String content) {
         return guide -> {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(guide).extracting("language").isEqualTo(language);
@@ -579,6 +703,10 @@ class FetchingServiceTest {
                         .containsExactlyInAnyOrderEntriesOf(keywords == null ? Map.of() : Map.of(language, keywords));
                 softly.assertThat(guide).extracting("categories", InstanceOfAssertFactories.COLLECTION)
                         .containsExactlyInAnyOrderElementsOf(categories);
+                softly.assertThat(guide).extracting("subcategories", InstanceOfAssertFactories.COLLECTION)
+                        .containsExactlyInAnyOrderElementsOf(subcategories);
+                softly.assertThat(guide).extracting("categoriesOrder", InstanceOfAssertFactories.LIST)
+                        .containsExactlyElementsOf(categoriesOrder);
                 softly.assertThat(guide)
                         .extracting(g -> g.topics.stream().map(I18nData::asMap).collect(Collectors.toList()),
                                 InstanceOfAssertFactories.COLLECTION)

--- a/src/test/java/io/quarkus/search/app/testsupport/QuarkusIOSample.java
+++ b/src/test/java/io/quarkus/search/app/testsupport/QuarkusIOSample.java
@@ -189,6 +189,10 @@ public final class QuarkusIOSample {
                     copyRootPath, copyGit,
                     collector.sourceCopyPathToOriginalPath, failOnMissing);
 
+            copyIfNecessary(originalRepo, branches.sources(),
+                    copyRootPath, copyGit,
+                    collector.optionalSourcesCopyPathToOriginalPath, false);
+
             editIfNecessary(originalRepo,
                     copyRootPath, copyGit,
                     collector.yamlQuarkusFilesToFilter);
@@ -232,8 +236,18 @@ public final class QuarkusIOSample {
         if (yamlQuarkusFilesToFilter.isEmpty()) {
             return;
         }
+        List<String> edited = new ArrayList<>();
         for (Map.Entry<String, Consumer<Path>> entry : yamlQuarkusFilesToFilter.entrySet()) {
-            entry.getValue().accept(copyRootPath.resolve(entry.getKey()));
+            Path fileToEdit = copyRootPath.resolve(entry.getKey());
+            if (!Files.exists(fileToEdit)) {
+                continue;
+            }
+            entry.getValue().accept(fileToEdit);
+            edited.add(entry.getKey());
+        }
+
+        if (edited.isEmpty()) {
+            return;
         }
 
         copyGit.add().addFilepattern(".").call();
@@ -243,8 +257,7 @@ public final class QuarkusIOSample {
                 Edited:%s"""
                 .formatted(
                         originalRepo,
-                        yamlQuarkusFilesToFilter.values().stream()
-                                .map(Object::toString)
+                        edited.stream()
                                 .collect(Collectors.joining("\n* ", "\n* ", "\n"))))
                 .call();
     }
@@ -269,6 +282,72 @@ public final class QuarkusIOSample {
             }
             return filtered;
         });
+    }
+
+    // Filters categories.yaml to only keep guides matching the test refs.
+    // Structure: categories -> [{id, title, guides?, subcategories -> [{id, title, guides}]}]
+    @SuppressWarnings("unchecked")
+    private static void yamlCategoriesEditor(String version, Path fileToEdit, GuideRef[] refs) {
+        yamlQuarkusEditor(fileToEdit, categoriesYaml -> {
+            Set<String> guideRefs = Arrays.stream(refs).map(g -> g.name(version)).collect(Collectors.toSet());
+
+            List<Map<String, Object>> categories = (List<Map<String, Object>>) categoriesYaml.get("categories");
+            List<Map<String, Object>> filteredCategories = new ArrayList<>();
+
+            if (categories != null) {
+                for (Map<String, Object> categoryObj : categories) {
+                    Map<String, Object> filteredCategory = new HashMap<>(categoryObj);
+                    boolean hasGuides = false;
+
+                    hasGuides |= filterGuideList(filteredCategory, "guides", guideRefs);
+                    hasGuides |= filterSubcategories(filteredCategory, guideRefs);
+
+                    if (hasGuides) {
+                        filteredCategories.add(filteredCategory);
+                    }
+                }
+            }
+
+            return Map.of("categories", filteredCategories);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean filterSubcategories(Map<String, Object> parent, Set<String> guideRefs) {
+        List<Map<String, Object>> subcategories = (List<Map<String, Object>>) parent.get("subcategories");
+        if (subcategories == null) {
+            return false;
+        }
+        List<Map<String, Object>> filtered = new ArrayList<>();
+        for (Map<String, Object> subcategoryObj : subcategories) {
+            Map<String, Object> copy = new HashMap<>(subcategoryObj);
+            if (filterGuideList(copy, "guides", guideRefs)) {
+                filtered.add(copy);
+            }
+        }
+        if (!filtered.isEmpty()) {
+            parent.put("subcategories", filtered);
+        } else {
+            parent.remove("subcategories");
+        }
+        return !filtered.isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean filterGuideList(Map<String, Object> parent, String key, Set<String> guideRefs) {
+        List<Map<String, Object>> guides = (List<Map<String, Object>>) parent.get(key);
+        if (guides == null) {
+            return false;
+        }
+        List<Map<String, Object>> filtered = guides.stream()
+                .filter(g -> guideRefs.contains(Objects.toString(g.get("url"), null)))
+                .collect(Collectors.toList());
+        if (!filtered.isEmpty()) {
+            parent.put(key, filtered);
+        } else {
+            parent.remove(key);
+        }
+        return !filtered.isEmpty();
     }
 
     private static void yamlVersionEditor(Path fileToEdit, Collection<String> versions) {
@@ -380,6 +459,7 @@ public final class QuarkusIOSample {
             c.addVersionMetadata(SAMPLED_VERSIONS);
             for (String version : SAMPLED_VERSIONS) {
                 c.addMetadata(version, guides);
+                c.addCategoriesMetadata(version, guides);
                 for (GuideRef guideRef : guides) {
                     c.addGuide(guideRef, version);
                 }
@@ -408,6 +488,7 @@ public final class QuarkusIOSample {
 
     public static class FilterDefinitionCollector {
         private final Map<String, String> sourceCopyPathToOriginalPath = new LinkedHashMap<>();
+        private final Map<String, String> optionalSourcesCopyPathToOriginalPath = new LinkedHashMap<>();
         private final Map<String, String> pagesCopyPathToOriginalPath = new LinkedHashMap<>();
         private final Map<String, Consumer<Path>> yamlQuarkusFilesToFilter = new LinkedHashMap<>();
 
@@ -439,6 +520,13 @@ public final class QuarkusIOSample {
             return this;
         }
 
+        public FilterDefinitionCollector addCategoriesMetadata(String version, GuideRef[] guides) {
+            String categoriesPath = QuarkusIO.yamlCategoriesMetadataPath(version).toString();
+            addOnSourceBranchIfExists(categoriesPath, categoriesPath);
+            addMetadataToFilter(categoriesPath, path -> yamlCategoriesEditor(version, path, guides));
+            return this;
+        }
+
         public FilterDefinitionCollector addLocalizedGuide(Language language, GuideRef ref, String version) {
             String htmlPath = QuarkusIO.htmlPath(language, version, ref.name(version));
             htmlPath = htmlPath.startsWith("/") ? htmlPath.substring(1) : htmlPath;
@@ -456,6 +544,11 @@ public final class QuarkusIOSample {
 
         public void addOnSourceBranch(String originalPath, String copyPath) {
             add("source", sourceCopyPathToOriginalPath, originalPath, copyPath);
+        }
+
+        // Files from the sources branch that may not exist upstream (e.g. categories.yaml for older versions)
+        public void addOnSourceBranchIfExists(String originalPath, String copyPath) {
+            add("sources", optionalSourcesCopyPathToOriginalPath, originalPath, copyPath);
         }
 
         public void addOnPagesBranch(String originalPath, String copyPath) {


### PR DESCRIPTION
- new yaml source of indexing
- new endpoint for searching by "groups"
- new lit components to handle the grouped search
- stop highlighting content
- adjust quarkiverse indexing and make sure it appears in grouped search
- make content indexing cleaner and drop more non-main-text blocks
- fix the clearing search-bar leaving q in the hash
- change guides relevance and boost guides listed first


we'll need to regenerate the zips once the changes propagate to all localised sites and fix some tests after that 🙈 