### PR TITLE
Skip tests when running the "deploy" job

### DIFF
--- a/.github/workflows/deploy-pr-staging.yml
+++ b/.github/workflows/deploy-pr-staging.yml
@@ -106,7 +106,8 @@ jobs:
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.registry="${{ steps.oc-registry.outputs.OC_REGISTRY_URL }}" \
-          -Dquarkus.container-image.group="$(oc project --short)"
+          -Dquarkus.container-image.group="$(oc project --short)" \
+          -DskipTests
 
     - name: Push Elasticsearch container image
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,8 @@ jobs:
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.registry="${{ steps.oc-registry.outputs.OC_REGISTRY_URL }}" \
-          -Dquarkus.container-image.group="$(oc project --short)"
+          -Dquarkus.container-image.group="$(oc project --short)" \
+          -DskipTests
 
     - name: Push Elasticsearch container image
       run: |


### PR DESCRIPTION
I think we are already running them in PRs and then after the merge (only to main though ...) so I wonder if we should just skip that ?